### PR TITLE
Expand ajax error handling

### DIFF
--- a/Scripts/GetHeadersRest.js
+++ b/Scripts/GetHeadersRest.js
@@ -108,8 +108,8 @@ function getHeaders(accessToken) {
         } else {
             showError(null, ImportedStrings.mha_headersMissing);
         }
-    }).fail(function (error) {
-        showError(null, JSON.stringify(error, null, 2));
+    }).fail(function (jqXHR, textStatus, errorThrown) {
+        showError(null, "textStatus: " + textStatus + '\nerrorThrown: ' + errorThrown + "\njqXHR: " + JSON.stringify(jqXHR, null, 2));
     }).always(function () {
         hideStatus();
     });


### PR DESCRIPTION
Still trying to narrow in on why ajax calls aren't giving proper error information so I can properly detect that REST is not supported and fallback to EWS