### PR TITLE
Fallback to ews when we can't get a call back token.

### DIFF
--- a/Scripts/GetHeadersRest.js
+++ b/Scripts/GetHeadersRest.js
@@ -18,7 +18,8 @@ function sendHeadersRequestRest(headersLoadedCallback) {
             var accessToken = result.value;
             getHeaders(accessToken, headersLoadedCallback);
         } else {
-            ShowError(null, 'Unable to obtain callback token.\n' + result.error);
+            ShowError(null, 'Unable to obtain callback token.\n' + JSON.stringify(result, null, 2));
+            sendHeadersRequestEWS(headersLoadedCallback);
         }
     });
 }


### PR DESCRIPTION
Keep logging an error so we can target this better.
Should make #52 work, while still logging so we can see what the error was