### PR TITLE
Extra blank lines in original header box.

### DIFF
--- a/src/Scripts/Headers.js
+++ b/src/Scripts/Headers.js
@@ -25,7 +25,8 @@ var HeaderModel = (function (headers) {
 
     function parseHeaders(headers) {
         // Initialize originalHeaders in case we have parsing problems
-        originalHeaders = headers;
+        // Flatten CRLF to LF to avoid extra blank lines
+        originalHeaders = headers.replace(/(?:\r\n|\r|\n)/g, '\n');
         var headerList = GetHeaderList(headers);
 
         if (headerList.length > 0) {


### PR DESCRIPTION
Happens if CRLF maps to LFLF in browser. Pre flatten to just LF to avoid this

Fixes #119