### PR TITLE
Accessibility Bug Fixes for MHA web/windows 

### DIFF
--- a/src/Content/App.css
+++ b/src/Content/App.css
@@ -282,3 +282,9 @@ button[aria-expanded="false"] .collapsibleSwitch::after {
     .tableHeaderButton .sortArrow::after { color: buttontext; }
     button .collapsibleSwitch::after { color: buttontext; }
 }
+
+/* bug fix 1691247 */
+.ms-Button.ms-Button--primary {
+    color: #FFFFFF;
+    background-color: #0677D3;
+}

--- a/src/Content/fabric.css
+++ b/src/Content/fabric.css
@@ -79,3 +79,19 @@ input[type="radio"]:focus+label {
         background-color: highlight;
     }
 }
+
+/* bug fix 1691683 */
+@media screen and (-ms-high-contrast: white-on-black) {
+    .ms-RadioButton-field.is-checked:after {
+        background-color: buttonborder;
+    }
+}
+
+/* bug fix 1697464 */
+.ms-RadioButton-field:before  {
+    border-color: #6C6B6B !important;
+ }
+
+ .ms-CheckBox-field:before {
+    border-color: #6C6B6B !important;
+ }

--- a/src/Pages/newDesktopFrame.html
+++ b/src/Pages/newDesktopFrame.html
@@ -10,25 +10,25 @@
             <div class="ms-CommandBar" id="nav-bar">
                 <div class="ms-CommandBar-mainArea">
                     <div class="ms-CommandButton ms-CommandButton--pivot is-active" data-content="summary-view">
-                        <button class="ms-CommandButton-button" id="summary-btn">
+                        <button class="ms-CommandButton-button" id="summary-btn" title="Summary">
                             <span class="ms-CommandButton-icon ms-fontColor-themePrimary"><i class="ms-Icon ms-Icon--Info"></i></span>
                             <span class="ms-CommandButton-label">Summary</span>
                         </button>
                     </div>
                     <div class="ms-CommandButton ms-CommandButton--pivot" data-content="received-view">
-                        <button class="ms-CommandButton-button">
+                        <button class="ms-CommandButton-button"  title="Received"> <!-- Bug fix 1696469 -->
                             <span class="ms-CommandButton-icon ms-fontColor-themePrimary"><i class="ms-Icon ms-Icon--Timer"></i></span>
                             <span class="ms-CommandButton-label">Received</span>
                         </button>
                     </div>
                     <div class="ms-CommandButton ms-CommandButton--pivot" data-content="antispam-view">
-                        <button class="ms-CommandButton-button">
+                        <button class="ms-CommandButton-button" title="Antispasm">
                             <span class="ms-CommandButton-icon ms-fontColor-themePrimary"><i class="ms-Icon ms-Icon--MailAlert"></i></span>
                             <span class="ms-CommandButton-label">Antispam</span>
                         </button>
                     </div>
                     <div class="ms-CommandButton ms-CommandButton--pivot" data-content="other-view">
-                        <button class="ms-CommandButton-button">
+                        <button class="ms-CommandButton-button" title="Other">
                             <span class="ms-CommandButton-icon ms-fontColor-themePrimary"><i class="ms-Icon ms-Icon--Cake"></i></span>
                             <span class="ms-CommandButton-label">Other</span>
                         </button>

--- a/src/Pages/newDesktopFrame.html
+++ b/src/Pages/newDesktopFrame.html
@@ -22,7 +22,7 @@
                         </button>
                     </div>
                     <div class="ms-CommandButton ms-CommandButton--pivot" data-content="antispam-view">
-                        <button class="ms-CommandButton-button" title="Antispasm">
+                        <button class="ms-CommandButton-button" title="Antispam">
                             <span class="ms-CommandButton-icon ms-fontColor-themePrimary"><i class="ms-Icon ms-Icon--MailAlert"></i></span>
                             <span class="ms-CommandButton-label">Antispam</span>
                         </button>


### PR DESCRIPTION
[1691247-](https://worldwidelearning.visualstudio.com/MCAPS%20Accessibility/_workitems/edit/1691247) Changed color contrast for Analyze header button on web MHA
[1691683](https://worldwidelearning.visualstudio.com/MCAPS%20Accessibility/_workitems/edit/1691683)- Added Media query for Aquatic mode radio button selection issue
[1697464](https://worldwidelearning.visualstudio.com/MCAPS%20Accessibility/_workitems/edit/1697464)- Fixed Luminosity contrast ratio of 'Radio buttons' and 'Check box',
[1696469 ](https://worldwidelearning.visualstudio.com/MCAPS%20Accessibility/_workitems/edit/1696469)- added title to the buttons for narrator to narrate name information of the buttons.