### PR TITLE
Improve stacks

### DIFF
--- a/src/Scripts/Errors.test.ts
+++ b/src/Scripts/Errors.test.ts
@@ -17,7 +17,7 @@ function testParse(done: jest.DoneCallback, exception: unknown, message: string 
 }
 
 describe("Errors.parse Tests", () => {
-    beforeAll(() => { Stack.options = { offline: true }; });
+    beforeAll(() => { Stack.options.offline = true; });
 
     test("stringError", done => {
         testParse(done, "stringError", "message", "message : stringError", [

--- a/src/Scripts/Errors.test.ts
+++ b/src/Scripts/Errors.test.ts
@@ -2,9 +2,10 @@
 import { expect } from "@jest/globals";
 
 import { Errors } from "./Errors";
+import { Stack } from "./stacks";
 
 function testParse(done: jest.DoneCallback, exception: unknown, message: string | null, expectedEventName: string, expectedStack: string[]) {
-    Errors.parse(exception, message, function (eventName, stack) {
+    Stack.parse(exception, message, function (eventName, stack) {
         try {
             expect(eventName).toBe(expectedEventName);
             expect(stack).stacksEqual(expectedStack);
@@ -16,9 +17,10 @@ function testParse(done: jest.DoneCallback, exception: unknown, message: string 
 }
 
 describe("Errors.parse Tests", () => {
+    beforeAll(() => { Stack.options = { offline: true }; });
+
     test("stringError", done => {
         testParse(done, "stringError", "message", "message : stringError", [
-            "Function.parse (src\\Scripts\\Errors.ts)",
             "testParse (src\\Scripts\\Errors.test.ts)",
             "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
             "processTicksAndRejections (node:internal/process/task_queues)"
@@ -46,7 +48,6 @@ describe("Errors.parse Tests", () => {
         catch (error) {
             testParse(done, error, "message", "message : 42",
                 [
-                    "Function.parse (src\\Scripts\\Errors.ts)",
                     "testParse (src\\Scripts\\Errors.test.ts)",
                     "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
                     "processTicksAndRejections (node:internal/process/task_queues)"
@@ -66,7 +67,6 @@ describe("Errors.parse Tests", () => {
                 "  \"three\": \"three\"\n" +
                 "}",
                 [
-                    "Function.parse (src\\Scripts\\Errors.ts)",
                     "testParse (src\\Scripts\\Errors.test.ts)",
                     "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
                     "processTicksAndRejections (node:internal/process/task_queues)"
@@ -81,7 +81,6 @@ describe("Errors.parse Tests", () => {
         catch (error) {
             testParse(done, error, null, "Unknown exception",
                 [
-                    "Function.parse (src\\Scripts\\Errors.ts)",
                     "testParse (src\\Scripts\\Errors.test.ts)",
                     "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
                     "processTicksAndRejections (node:internal/process/task_queues)"
@@ -91,7 +90,6 @@ describe("Errors.parse Tests", () => {
 
     test("null error and string message", done => {
         testParse(done, null, "message", "message", [
-            "Function.parse (src\\Scripts\\Errors.ts)",
             "testParse (src\\Scripts\\Errors.test.ts)",
             "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
             "processTicksAndRejections (node:internal/process/task_queues)"
@@ -100,7 +98,6 @@ describe("Errors.parse Tests", () => {
 
     test("null error and null message", done => {
         testParse(done, null, null, "Unknown exception", [
-            "Function.parse (src\\Scripts\\Errors.ts)",
             "testParse (src\\Scripts\\Errors.test.ts)",
             "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
             "processTicksAndRejections (node:internal/process/task_queues)"
@@ -117,7 +114,6 @@ describe("Errors.parse Tests", () => {
 
     test("integer error and string message", done => {
         testParse(done, 42, "message", "message : 42", [
-            "Function.parse (src\\Scripts\\Errors.ts)",
             "testParse (src\\Scripts\\Errors.test.ts)",
             "Object.<anonymous> (src\\Scripts\\Errors.test.ts)",
             "processTicksAndRejections (node:internal/process/task_queues)"

--- a/src/Scripts/stacks.ts
+++ b/src/Scripts/stacks.ts
@@ -1,0 +1,61 @@
+import { StackFrame, StackTraceOptions } from "stacktrace-js";
+import * as stackTrace from "stacktrace-js";
+
+import { diagnostics } from "./Diag";
+import { Errors } from "./Errors";
+import { Strings } from "./Strings";
+
+export class Stack {
+    public static options: StackTraceOptions = {offline: false};
+
+    // While trying to get our error tracking under control, let's not filter our stacks
+    private static async filterStack(stack: StackFrame[]): Promise<StackFrame[]> {
+        return stack.filter(function (item: StackFrame) {
+            if (!item.fileName) return true;
+            if (item.fileName.indexOf("stacktrace") !== -1) return false; // remove stacktrace.js frames
+            //if (item.functionName === "ShowError") return false;
+            //if (item.functionName === "showError") return false;
+            //if (item.functionName === "Errors.log") return false; // Logs with Errors.log in them usually have location where it was called from - keep those
+            //if (item.functionName === "GetStack") return false;
+            if (item.functionName === "Function.getExceptionStack") return false;
+            if (item.functionName === "Stack.getExceptionStack") return false;
+            if (item.functionName === "Function.parse") return false;
+            if (item.functionName === "Stack.parse") return false;
+            if (item.functionName === "Errors.isError") return false; // Not called from anywhere interesting
+            if (item.functionName?.indexOf("Promise._immediateFn") !== -1) return false; // only shows in IE stacks
+            return true;
+        });
+    }
+
+    public static async getExceptionStack(exception: unknown): Promise<StackFrame[]> {
+        let stack;
+        if (!Errors.isError(exception)) {
+            stack = await stackTrace.get(Stack.options);
+        } else {
+            stack = await stackTrace.fromError(exception as Error, Stack.options);
+        }
+
+        return Stack.filterStack(stack);
+    }
+
+    public static parse(exception: unknown, message: string | null, handler: (eventName: string, stack: string[]) => void): void {
+        let stack;
+        const exceptionMessage = Errors.getErrorMessage(exception);
+
+        let eventName = Strings.joinArray([message, exceptionMessage], " : ");
+        if (!eventName) {
+            eventName = "Unknown exception";
+        }
+
+        this.getExceptionStack(exception).then((stackframes) => {
+            stack = stackframes.map(function (sf) {
+                return sf.toString();
+            });
+            handler(eventName, stack);
+        }).catch((err) => {
+            diagnostics.trackEvent({ name: "Errors.parse errback" });
+            stack = [JSON.stringify(exception, null, 2), "Parsing error:", JSON.stringify(err, null, 2)];
+            handler(eventName, stack);
+        });
+    }
+}

--- a/src/Scripts/stacks.ts
+++ b/src/Scripts/stacks.ts
@@ -6,25 +6,23 @@ import { Errors } from "./Errors";
 import { Strings } from "./Strings";
 
 export class Stack {
-    public static options: StackTraceOptions = {offline: false};
+    public static options: StackTraceOptions = {offline: false, filter: Stack.filterStack};
 
     // While trying to get our error tracking under control, let's not filter our stacks
-    private static async filterStack(stack: StackFrame[]): Promise<StackFrame[]> {
-        return stack.filter(function (item: StackFrame) {
-            if (!item.fileName) return true;
-            if (item.fileName.indexOf("stacktrace") !== -1) return false; // remove stacktrace.js frames
-            if (item.fileName.indexOf("stacks.ts") !== -1) return false; // remove stacks.ts frames
-            //if (item.functionName === "ShowError") return false;
-            //if (item.functionName === "showError") return false;
-            //if (item.functionName === "Errors.log") return false; // Logs with Errors.log in them usually have location where it was called from - keep those
-            //if (item.functionName === "GetStack") return false;
-            if (item.functionName === "Errors.isError") return false; // Not called from anywhere interesting
-            if (item.functionName?.indexOf("Promise._immediateFn") !== -1) return false; // only shows in IE stacks
-            return true;
-        });
+    private static filterStack(item: StackFrame):boolean {
+        if (!item.fileName) return true;
+        if (item.fileName.indexOf("stacktrace") !== -1) return false; // remove stacktrace.js frames
+        if (item.fileName.indexOf("stacks.ts") !== -1) return false; // remove stacks.ts frames
+        //if (item.functionName === "ShowError") return false;
+        //if (item.functionName === "showError") return false;
+        //if (item.functionName === "Errors.log") return false; // Logs with Errors.log in them usually have location where it was called from - keep those
+        //if (item.functionName === "GetStack") return false;
+        if (item.functionName === "Errors.isError") return false; // Not called from anywhere interesting
+        if (item.functionName?.indexOf("Promise._immediateFn") !== -1) return false; // only shows in IE stacks
+        return true;
     }
 
-    public static async getExceptionStack(exception: unknown): Promise<StackFrame[]> {
+    private static async getExceptionStack(exception: unknown): Promise<StackFrame[]> {
         let stack;
         if (!Errors.isError(exception)) {
             stack = await stackTrace.get(Stack.options);
@@ -32,7 +30,7 @@ export class Stack {
             stack = await stackTrace.fromError(exception as Error, Stack.options);
         }
 
-        return Stack.filterStack(stack);
+        return stack;
     }
 
     public static parse(exception: unknown, message: string | null, handler: (eventName: string, stack: string[]) => void): void {

--- a/src/Scripts/stacks.ts
+++ b/src/Scripts/stacks.ts
@@ -21,6 +21,8 @@ export class Stack {
             if (item.functionName === "Stack.getExceptionStack") return false;
             if (item.functionName === "Function.parse") return false;
             if (item.functionName === "Stack.parse") return false;
+            if (item.functionName === "Function.getExceptionStack [as parse]") return false;
+            if (item.functionName === "Function.get [as getExceptionStack]") return false;
             if (item.functionName === "Errors.isError") return false; // Not called from anywhere interesting
             if (item.functionName?.indexOf("Promise._immediateFn") !== -1) return false; // only shows in IE stacks
             return true;

--- a/src/Scripts/stacks.ts
+++ b/src/Scripts/stacks.ts
@@ -13,16 +13,11 @@ export class Stack {
         return stack.filter(function (item: StackFrame) {
             if (!item.fileName) return true;
             if (item.fileName.indexOf("stacktrace") !== -1) return false; // remove stacktrace.js frames
+            if (item.fileName.indexOf("stacks.ts") !== -1) return false; // remove stacks.ts frames
             //if (item.functionName === "ShowError") return false;
             //if (item.functionName === "showError") return false;
             //if (item.functionName === "Errors.log") return false; // Logs with Errors.log in them usually have location where it was called from - keep those
             //if (item.functionName === "GetStack") return false;
-            if (item.functionName === "Function.getExceptionStack") return false;
-            if (item.functionName === "Stack.getExceptionStack") return false;
-            if (item.functionName === "Function.parse") return false;
-            if (item.functionName === "Stack.parse") return false;
-            if (item.functionName === "Function.getExceptionStack [as parse]") return false;
-            if (item.functionName === "Function.get [as getExceptionStack]") return false;
             if (item.functionName === "Errors.isError") return false; // Not called from anywhere interesting
             if (item.functionName?.indexOf("Promise._immediateFn") !== -1) return false; // only shows in IE stacks
             return true;

--- a/src/Scripts/ui/getHeaders/GetHeaders.ts
+++ b/src/Scripts/ui/getHeaders/GetHeaders.ts
@@ -63,6 +63,7 @@ export class GetHeaders {
     }
 
     public static async send(headersLoadedCallback: (_headers: string, apiUsed: string) => void) {
+        Errors.log(null, "GetHeaders.send", true);
         if (!GetHeaders.validItem()) {
             ParentFrame.showError(null, "No item selected", true);
             return;

--- a/src/Scripts/ui/getHeaders/GetHeaders.ts
+++ b/src/Scripts/ui/getHeaders/GetHeaders.ts
@@ -63,7 +63,6 @@ export class GetHeaders {
     }
 
     public static async send(headersLoadedCallback: (_headers: string, apiUsed: string) => void) {
-        Errors.log(null, "GetHeaders.send", true);
         if (!GetHeaders.validItem()) {
             ParentFrame.showError(null, "No item selected", true);
             return;


### PR DESCRIPTION
This pull request refactors the error handling and stack trace parsing logic by moving the `parse` method from the `Errors` class to a new `Stack` class. Additionally, it updates the corresponding test cases to reflect these changes.

Refactoring error handling:

* [`src/Scripts/Errors.ts`](diffhunk://#diff-49e865026b4e9acc65cb205ff20d1c5227b380891bed3960338fe0e67c188739L1-R2): Removed the `parse` method from the `Errors` class and replaced its usage with the new `Stack.parse` method. [[1]](diffhunk://#diff-49e865026b4e9acc65cb205ff20d1c5227b380891bed3960338fe0e67c188739L1-R2) [[2]](diffhunk://#diff-49e865026b4e9acc65cb205ff20d1c5227b380891bed3960338fe0e67c188739L83-R81) [[3]](diffhunk://#diff-49e865026b4e9acc65cb205ff20d1c5227b380891bed3960338fe0e67c188739L92-L141)
* [`src/Scripts/stacks.ts`](diffhunk://#diff-ecef990570ceb8b3e0c74f6d4fd91c916210a99754abaa6691f65f7a3ea9b4a5R1-R56): Added a new `Stack` class that includes the `parse` method and stack filtering logic previously in the `Errors` class.

Updating test cases:

* [`src/Scripts/Errors.test.ts`](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129R5-R8): Updated the import statement to include the new `Stack` class and modified the `testParse` function to use `Stack.parse` instead of `Errors.parse`. Added a `beforeAll` hook to set `Stack.options.offline` to `true`. [[1]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129R5-R8) [[2]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129R20-L21) [[3]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L49) [[4]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L69) [[5]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L84) [[6]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L94) [[7]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L103) [[8]](diffhunk://#diff-253c38da799af32041458948b6eb4c2e39970adb7cc9b9437645ece28c0a3129L120)