### PR TITLE
Migrate to latest framework7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@microsoft/office-js": "^1.1.110",
         "codepage": "^1.15.0",
         "dayjs": "^1.11.13",
-        "framework7": "^1.7.1",
+        "framework7": "^8.3.4",
         "framework7-icons": "^5.0.5",
         "jquery": "^3.7.1",
         "jwt-decode": "^4.0.0",
@@ -8055,6 +8055,15 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/dom7": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/dom7/-/dom7-4.0.6.tgz",
+      "integrity": "sha512-emjdpPLhpNubapLFdjNL9tP06Sr+GZkrIHEXLWvOGsytACUrkbeIdjO5g77m00BrHTznnlcNqgmn7pCN192TBA==",
+      "license": "MIT",
+      "dependencies": {
+        "ssr-window": "^4.0.0"
+      }
+    },
     "node_modules/domelementtype": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
@@ -9520,9 +9529,22 @@
       }
     },
     "node_modules/framework7": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/framework7/-/framework7-1.7.1.tgz",
-      "integrity": "sha512-Az85Cnb9UOYztQW9XSeLsGxKB/4Z8+dZCZTZjnsnBLG7p+2KF75QBkgq/npe6tvTHyQDTnG5Up0cNwxiLSwx1g=="
+      "version": "8.3.4",
+      "resolved": "https://registry.npmjs.org/framework7/-/framework7-8.3.4.tgz",
+      "integrity": "sha512-RKrEeNTxKEzhxJMaw8hLoIZbzHMzLZDFmQlpbxYFUqxyGDH8r6+NFGDCxOFnpkP1VI+L5UsDenrxo8vEzh929Q==",
+      "license": "MIT",
+      "dependencies": {
+        "dom7": "^4.0.6",
+        "htm": "^3.1.1",
+        "path-to-regexp": "^6.2.0",
+        "skeleton-elements": "^4.0.1",
+        "ssr-window": "^4.0.2",
+        "swiper": "^10.2.0"
+      },
+      "funding": {
+        "type": "patreon",
+        "url": "https://www.patreon.com/framework7"
+      }
     },
     "node_modules/framework7-icons": {
       "version": "5.0.5",
@@ -9531,6 +9553,12 @@
       "engines": {
         "node": ">= 0.10.0"
       }
+    },
+    "node_modules/framework7/node_modules/path-to-regexp": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "license": "MIT"
     },
     "node_modules/fresh": {
       "version": "0.5.2",
@@ -10040,6 +10068,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/htm": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/htm/-/htm-3.1.1.tgz",
+      "integrity": "sha512-983Vyg8NwUE7JkZ6NmOqpCZ+sh1bKv2iYTlUkzlWmA5JD2acKoxd4KVxbMmxX/85mtfdnDmTFoNKcg5DGAvxNQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/html-encoding-sniffer": {
       "version": "4.0.0",
@@ -17201,6 +17235,12 @@
         "node": ">= 10"
       }
     },
+    "node_modules/skeleton-elements": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/skeleton-elements/-/skeleton-elements-4.0.1.tgz",
+      "integrity": "sha512-T7YSF/Vu/raUcM6v3HiE4VSY/OvrNflg8Dur3Zza6VVJkq4slxm4pJRpGLNhoOfblIPZLQKh1cu7ADKveyqm/Q==",
+      "license": "MIT"
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -17305,6 +17345,12 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true
+    },
+    "node_modules/ssr-window": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/ssr-window/-/ssr-window-4.0.2.tgz",
+      "integrity": "sha512-ISv/Ch+ig7SOtw7G2+qkwfVASzazUnvlDTwypdLoPoySv+6MqlOV10VwPSE6EWkGjhW50lUmghPmpYZXMu/+AQ==",
+      "license": "MIT"
     },
     "node_modules/stable-hash-x": {
       "version": "0.2.0",
@@ -17661,6 +17707,25 @@
       "peer": true,
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-10.3.1.tgz",
+      "integrity": "sha512-24Wk3YUdZHxjc9faID97GTu6xnLNia+adMt6qMTZG/HgdSUt4fS0REsGUXJOgpTED0Amh/j+gRGQxsLayJUlBQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/symbol-tree": {

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "@microsoft/office-js": "^1.1.110",
     "codepage": "^1.15.0",
     "dayjs": "^1.11.13",
-    "framework7": "^1.7.1",
+    "framework7": "^8.3.4",
     "framework7-icons": "^5.0.5",
     "jquery": "^3.7.1",
     "jwt-decode": "^4.0.0",

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -74,10 +74,17 @@ a.tab-link {
     }
 }
 
-.list-block .item-link .item-inner, .list-block .list-button .item-inner {
+/* Only show chevron arrows on accordion items that can be collapsed/expanded */
+.list-block .accordion-item .item-link .item-inner {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%20120%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27m60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 15px center;
+    background-size: 15px;
 }
 
-.list-block .accordion-item-expanded.media-item .accordion-item-toggle .item-title-row,.list-block .accordion-item-expanded.media-item>.item-link .item-title-row,.list-block.media-list .accordion-item-expanded .accordion-item-toggle .item-title-row,.list-block.media-list .accordion-item-expanded>.item-link .item-title-row,.list-block:not(.media-list) .accordion-item-expanded:not(.media-item) .accordion-item-toggle .item-inner,.list-block:not(.media-list) .accordion-item-expanded:not(.media-item)>.item-link .item-inner {
+.list-block .accordion-item-expanded .item-link .item-inner {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20transform%3D'translate(115%2C%2030)%20rotate(90)'%20fill%3D'%23000000'%2F%3E%3C%2Fsvg%3E");
+    background-repeat: no-repeat;
+    background-position: right 15px center;
+    background-size: 15px;
 }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -14,8 +14,8 @@
     --f7-timeline-item-text-color: black;
     --f7-tabs-bg-color: #f4f4f4;
     --f7-link-color: black;
-    --f7-accordion-chevron-icon-down: 'chevron_right';
-    --f7-accordion-chevron-icon-up: 'chevron_down';
+    --f7-accordion-chevron-icon-down: "chevron_right";
+    --f7-accordion-chevron-icon-up: "chevron_down";
     --f7-timeline-item-inner-bg-color: white;
     --f7-page-bg-color: var(-f7-tabs-bg-color);
 }
@@ -33,10 +33,15 @@ body {
     bottom: 0;
 }
 
+.top-spacer {
+    height: 44px;
+}
+
 /* Ensure page doesn't scroll behind toolbars */
 .page {
-    padding-top: 44px; /* Push content below top toolbar */
-    padding-bottom: var(--f7-tabbar-icons-height, 50px); /* Use Framework7's exact tabbar height for iOS */
+    position: relative;
+    height: calc(100vh - 44px - 24px);
+    overflow-y: auto;
 }
 
 /* Framework7 v8 tab styling */
@@ -107,7 +112,7 @@ a.tab-link {
     overflow: visible;
 }
 
-@media screen and (-ms-high-contrast:active) {
+@media screen and (-ms-high-contrast: active) {
     .progressbar span {
         background: highlight;
     }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -101,26 +101,22 @@ a.tab-link {
     }
 }
 
-/* Hide collapsed accordion content using height/overflow so Framework7 can animate height.
-   Avoid display:none which prevents measuring or animating height. */
-.accordion-item:not(.accordion-item-expanded) .accordion-item-content {
-    height: 0;
-    overflow: hidden;
-    padding-top: 0;
-    padding-bottom: 0;
+/* Hide native framework7 chevron */
+.list:not(.media-list) .accordion-item:not(.media-item) > .item-link .item-inner:before {
+    content:"";
 }
 
 /* Only show chevron arrows on accordion items that can be collapsed/expanded */
-.list .accordion-item .item-link .item-inner {
+.list .accordion-item:not(.accordion-item-opened) .item-link .item-inner {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%20120%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27m60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
     background-repeat: no-repeat;
     background-position: right 15px center;
     background-size: 15px;
 }
 
-.list .accordion-item-expanded .item-link .item-inner {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20transform%3D'translate(115%2C%2030)%20rotate(90)'%20fill%3D'%23000000'%2F%3E%3C%2Fsvg%3E");
+.list .accordion-item-opened .item-link .item-inner {
+    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%2060%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27M15%2020l15%2015%2015-15-5-5-10%2010-10-10z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
     background-repeat: no-repeat;
-    background-position: right 15px center;
-    background-size: 15px;
+    background-position: right 10px center;
+    background-size: contain;
 }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -94,7 +94,13 @@ a.tab-link {
 .block-title {
     overflow: visible;
 }
-/* See MutationObserver in renderItem to see how we set the height back to auto after this */
+
+@media screen and (-ms-high-contrast:active) {
+    .progressbar span {
+        background: highlight;
+    }
+}
+
 /* Hide collapsed accordion content using height/overflow so Framework7 can animate height.
    Avoid display:none which prevents measuring or animating height. */
 .accordion-item:not(.accordion-item-expanded) .accordion-item-content {
@@ -102,12 +108,6 @@ a.tab-link {
     overflow: hidden;
     padding-top: 0;
     padding-bottom: 0;
-}
-
-@media screen and (-ms-high-contrast:active) {
-    .progressbar span {
-        background: highlight;
-    }
 }
 
 /* Only show chevron arrows on accordion items that can be collapsed/expanded */

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -74,6 +74,10 @@ body {
     white-space: normal;
 }
 
+.tab .block-title:first-child {
+    margin-top: 0px;
+}
+
 .block {
     word-wrap: break-word;
 }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -1,4 +1,15 @@
 /* Framework7 specific overrides */
+
+/* Framework7 v8 tab styling */
+.tabs .tab {
+    background: #f4f4f4;
+    display: none;
+}
+
+.tabs .tab.tab-active {
+    display: block;
+}
+
 .code-box>pre {
     background-color: #eaeaea;
     border: 1px solid #ccc;

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -75,8 +75,13 @@ a.tab-link {
     overflow: visible;
 }
 /* See MutationObserver in renderItem to see how we set the height back to auto after this */
+/* Hide collapsed accordion content using height/overflow so Framework7 can animate height.
+   Avoid display:none which prevents measuring or animating height. */
 .accordion-item:not(.accordion-item-expanded) .accordion-item-content {
-        display: none;
+    height: 0;
+    overflow: hidden;
+    padding-top: 0;
+    padding-bottom: 0;
 }
 
 @media screen and (-ms-high-contrast:active) {

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -1,5 +1,25 @@
 /* Framework7 specific overrides */
 
+/* Reserve space for parent frame toolbar overlay */
+body {
+    margin: 0;
+    padding: 0;
+}
+
+.framework7-root {
+    position: absolute;
+    top: 44px; /* Reserve 44px at top for parent toolbar */
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: calc(100vh - 44px); /* Reduce height by toolbar space */
+}
+
+/* Ensure page content doesn't scroll behind bottom toolbar */
+.page-content {
+    padding-bottom: var(--f7-tabbar-icons-height, 50px); /* Use Framework7's exact tabbar height for iOS */
+}
+
 /* Framework7 v8 tab styling */
 .tabs .tab {
     background: #f4f4f4;

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -40,12 +40,12 @@
     background: #f4f4f4;
 }
 
-.content-block-title {
+.block-title {
     text-transform: none;
     white-space: normal;
 }
 
-.content-block {
+.block {
     word-wrap: break-word;
 }
 
@@ -71,7 +71,7 @@ a.tab-link {
     text-decoration: none;
 }
 
-.content-block-title {
+.block-title {
     overflow: visible;
 }
 /* See MutationObserver in renderItem to see how we set the height back to auto after this */
@@ -86,14 +86,14 @@ a.tab-link {
 }
 
 /* Only show chevron arrows on accordion items that can be collapsed/expanded */
-.list-block .accordion-item .item-link .item-inner {
+.list .accordion-item .item-link .item-inner {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%20120%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27m60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
     background-repeat: no-repeat;
     background-position: right 15px center;
     background-size: 15px;
 }
 
-.list-block .accordion-item-expanded .item-link .item-inner {
+.list .accordion-item-expanded .item-link .item-inner {
     background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D'0%200%2060%20120'%20xmlns%3D'http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg'%3E%3Cpath%20d%3D'm60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z'%20transform%3D'translate(115%2C%2030)%20rotate(90)'%20fill%3D'%23000000'%2F%3E%3C%2Fsvg%3E");
     background-repeat: no-repeat;
     background-position: right 15px center;

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -101,22 +101,11 @@ a.tab-link {
     }
 }
 
-/* Hide native framework7 chevron */
-.list:not(.media-list) .accordion-item:not(.media-item) > .item-link .item-inner:before {
-    content:"";
+.list:not(.media-list) .accordion-item:not(.media-item):not(.accordion-item-opened) > .item-link .item-inner:before {
+    content: var(--f7-accordion-chevron-icon-up);
+    transform: rotate(90deg); /* We actually want the chevron pointing right */
 }
 
-/* Only show chevron arrows on accordion items that can be collapsed/expanded */
-.list .accordion-item:not(.accordion-item-opened) .item-link .item-inner {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%20120%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27m60%2061.5-38.25%2038.25-9.75-9.75%2029.25-28.5-29.25-28.5%209.75-9.75z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
-    background-repeat: no-repeat;
-    background-position: right 15px center;
-    background-size: 15px;
-}
-
-.list .accordion-item-opened .item-link .item-inner {
-    background-image: url("data:image/svg+xml;charset=utf-8,%3Csvg%20viewBox%3D%270%200%2060%2060%27%20xmlns%3D%27http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%27%3E%3Cpath%20d%3D%27M15%2020l15%2015%2015-15-5-5-10%2010-10-10z%27%20fill%3D%27%23000000%27%2F%3E%3C%2Fsvg%3E");
-    background-repeat: no-repeat;
-    background-position: right 10px center;
-    background-size: contain;
+.list:not(.media-list) .accordion-item-opened:not(.media-item) > .item-link .item-inner:before {
+    content: var(--f7-accordion-chevron-icon-down);
 }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -125,3 +125,43 @@ a.tab-link {
     font-size: 17px;
     background: white;
 }
+
+/* Timeline styling for received view */
+#received-view .timeline-item-inner {
+    background: white;
+    color: black;
+    padding: 10px;
+    margin: 5px 0;
+    border-radius: 5px;
+    display: flex;
+    flex-direction: column; /* Stack elements vertically like bricks */
+    align-items: flex-start; /* Left align all content */
+    text-align: left;
+    word-wrap: break-word;
+}
+
+#received-view .timeline-item-time {
+    order: 1; /* Time at top */
+    font-weight: bold;
+    margin-bottom: 5px;
+}
+
+#received-view .timeline-item-subtitle {
+    order: 2; /* Subtitle second */
+    margin-bottom: 5px;
+    word-wrap: break-word;
+}
+
+#received-view .timeline-item-text {
+    order: 3; /* Text content third */
+    word-wrap: break-word;
+    width: 100%;
+}
+
+#received-view .progressbar {
+    background-color: #cccccc;
+}
+
+#received-view .progressbar span {
+    background-color: #007aff;
+}

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -109,3 +109,19 @@ a.tab-link {
 .list:not(.media-list) .accordion-item-opened:not(.media-item) > .item-link .item-inner:before {
     content: var(--f7-accordion-chevron-icon-down);
 }
+
+/* Antispam page styling */
+#antispam-view .block-title {
+    color: #555555;
+}
+
+#antispam-view .accordion-item {
+    background: white;
+    border-top: 1px solid #e0e0e0;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+#antispam-view .accordion-item .item-title {
+    font-size: 17px;
+    background: white;
+}

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -27,7 +27,6 @@ body {
 
 .framework7-root {
     position: absolute;
-    top: 44px; /* Reserve 44px at top for parent toolbar */
     left: 0;
     right: 0;
     bottom: 0;
@@ -67,10 +66,6 @@ body {
 
 .wrap-line {
     word-wrap: break-word;
-}
-
-.tabs .tab {
-    padding-top: 25px;
 }
 
 .page {

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -30,11 +30,11 @@ body {
     left: 0;
     right: 0;
     bottom: 0;
-    height: calc(100vh - 44px); /* Reduce height by toolbar space */
 }
 
-/* Ensure page content doesn't scroll behind bottom toolbar */
-.page-content {
+/* Ensure page doesn't scroll behind toolbars */
+.page {
+    padding-top: 44px; /* Push content below top toolbar */
     padding-bottom: var(--f7-tabbar-icons-height, 50px); /* Use Framework7's exact tabbar height for iOS */
 }
 

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -1,16 +1,21 @@
 /* Framework7 specific overrides */
 
 :root {
-    --background-grey: #f4f4f4;
     --code-box-bg: #eaeaea;
     --border-light-grey: #ccc;
     --text-dark-grey: #444;
     --text-medium-grey: #555555;
     --focus-outline-blue: #0072cc;
     --light-grey-border: #e0e0e0;
-    --progress-bg-grey: #cccccc;
-    --progress-blue: #007aff;
     --f7-block-title-text-color: black;
+    --f7-progressbar-bg-color: #cccccc;
+    --f7-progressbar-progress-color: #007aff;
+    --f7-timeline-item-inner-bg-color: white;
+    --f7-timeline-item-text-color: black;
+    --f7-tabs-bg-color: #f4f4f4;
+    --f7-link-color: black;
+    --f7-accordion-chevron-icon-down: 'chevron_right';
+    --f7-accordion-chevron-icon-up: 'chevron_down';
 }
 
 /* Reserve space for parent frame toolbar overlay */
@@ -35,7 +40,6 @@ body {
 
 /* Framework7 v8 tab styling */
 .tabs .tab {
-    background: var(--background-grey);
     display: none;
 }
 
@@ -66,11 +70,10 @@ body {
 
 .tabs .tab {
     padding-top: 25px;
-    background: var(--background-grey);
 }
 
 .page {
-    background: var(--background-grey);
+    background: var(--f7-tabs-bg-color);
 }
 
 .block-title {
@@ -84,7 +87,6 @@ body {
 
 a,
 a:visited {
-    color: black;
     text-decoration: underline;
 }
 
@@ -112,15 +114,6 @@ a.tab-link {
     .progressbar span {
         background: highlight;
     }
-}
-
-.list:not(.media-list) .accordion-item:not(.media-item):not(.accordion-item-opened) > .item-link .item-inner:before {
-    content: var(--f7-accordion-chevron-icon-up);
-    transform: rotate(90deg); /* We actually want the chevron pointing right */
-}
-
-.list:not(.media-list) .accordion-item-opened:not(.media-item) > .item-link .item-inner:before {
-    content: var(--f7-accordion-chevron-icon-down);
 }
 
 #antispam-view .block-title {
@@ -152,27 +145,16 @@ a.tab-link {
 }
 
 #received-view .timeline-item-time {
-    /* order: 1; */
     font-weight: bold;
     margin-bottom: 5px;
 }
 
 #received-view .timeline-item-subtitle {
-    /* order: 2; */
     margin-bottom: 5px;
     word-wrap: break-word;
 }
 
 #received-view .timeline-item-text {
-    /* order: 3; */
     word-wrap: break-word;
     width: 100%;
-}
-
-#received-view .progressbar {
-    background-color: var(--progress-bg-grey);
-}
-
-#received-view .progressbar span {
-    background-color: var(--progress-blue);
 }

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -17,6 +17,7 @@
     --f7-accordion-chevron-icon-down: 'chevron_right';
     --f7-accordion-chevron-icon-up: 'chevron_down';
     --f7-timeline-item-inner-bg-color: white;
+    --f7-page-bg-color: var(-f7-tabs-bg-color);
 }
 
 /* Reserve space for parent frame toolbar overlay */
@@ -66,10 +67,6 @@ body {
 
 .wrap-line {
     word-wrap: break-word;
-}
-
-.page {
-    background: var(--f7-tabs-bg-color);
 }
 
 .block-title {

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -16,6 +16,7 @@
     --f7-link-color: black;
     --f7-accordion-chevron-icon-down: 'chevron_right';
     --f7-accordion-chevron-icon-up: 'chevron_down';
+    --f7-timeline-item-inner-bg-color: white;
 }
 
 /* Reserve space for parent frame toolbar overlay */
@@ -132,8 +133,6 @@ a.tab-link {
 }
 
 #received-view .timeline-item-inner {
-    background: white;
-    color: black;
     padding: 10px;
     margin: 5px 0;
     border-radius: 5px;

--- a/src/Content/newMobilePaneIosFrame.css
+++ b/src/Content/newMobilePaneIosFrame.css
@@ -1,5 +1,18 @@
 /* Framework7 specific overrides */
 
+:root {
+    --background-grey: #f4f4f4;
+    --code-box-bg: #eaeaea;
+    --border-light-grey: #ccc;
+    --text-dark-grey: #444;
+    --text-medium-grey: #555555;
+    --focus-outline-blue: #0072cc;
+    --light-grey-border: #e0e0e0;
+    --progress-bg-grey: #cccccc;
+    --progress-blue: #007aff;
+    --f7-block-title-text-color: black;
+}
+
 /* Reserve space for parent frame toolbar overlay */
 body {
     margin: 0;
@@ -22,7 +35,7 @@ body {
 
 /* Framework7 v8 tab styling */
 .tabs .tab {
-    background: #f4f4f4;
+    background: var(--background-grey);
     display: none;
 }
 
@@ -31,8 +44,8 @@ body {
 }
 
 .code-box>pre {
-    background-color: #eaeaea;
-    border: 1px solid #ccc;
+    background-color: var(--code-box-bg);
+    border: 1px solid var(--border-light-grey);
     padding: 5px 10px;
     word-wrap: break-word;
     white-space: pre-wrap;
@@ -53,11 +66,11 @@ body {
 
 .tabs .tab {
     padding-top: 25px;
-    background: #f4f4f4;
+    background: var(--background-grey);
 }
 
 .page {
-    background: #f4f4f4;
+    background: var(--background-grey);
 }
 
 .block-title {
@@ -71,17 +84,17 @@ body {
 
 a,
 a:visited {
-    color: #000000;
+    color: black;
     text-decoration: underline;
 }
 
 a:hover {
-    color: #444;
+    color: var(--text-dark-grey);
 }
 
 a:focus,
 div:focus {
-    outline: #0072cc solid 2px;
+    outline: var(--focus-outline-blue) solid 2px;
     outline-offset: 2px;
 }
 
@@ -110,23 +123,21 @@ a.tab-link {
     content: var(--f7-accordion-chevron-icon-down);
 }
 
-/* Antispam page styling */
 #antispam-view .block-title {
-    color: #555555;
+    color: var(--text-medium-grey);
 }
 
 #antispam-view .accordion-item {
     background: white;
-    border-top: 1px solid #e0e0e0;
-    border-bottom: 1px solid #e0e0e0;
+    border-top: 1px solid var(--light-grey-border);
+    border-bottom: 1px solid var(--light-grey-border);
 }
 
 #antispam-view .accordion-item .item-title {
     font-size: 17px;
-    background: white;
+    background: var(--white);
 }
 
-/* Timeline styling for received view */
 #received-view .timeline-item-inner {
     background: white;
     color: black;
@@ -134,34 +145,34 @@ a.tab-link {
     margin: 5px 0;
     border-radius: 5px;
     display: flex;
-    flex-direction: column; /* Stack elements vertically like bricks */
-    align-items: flex-start; /* Left align all content */
+    flex-direction: column;
+    align-items: flex-start;
     text-align: left;
     word-wrap: break-word;
 }
 
 #received-view .timeline-item-time {
-    order: 1; /* Time at top */
+    /* order: 1; */
     font-weight: bold;
     margin-bottom: 5px;
 }
 
 #received-view .timeline-item-subtitle {
-    order: 2; /* Subtitle second */
+    /* order: 2; */
     margin-bottom: 5px;
     word-wrap: break-word;
 }
 
 #received-view .timeline-item-text {
-    order: 3; /* Text content third */
+    /* order: 3; */
     word-wrap: break-word;
     width: 100%;
 }
 
 #received-view .progressbar {
-    background-color: #cccccc;
+    background-color: var(--progress-bg-grey);
 }
 
 #received-view .progressbar span {
-    background-color: #007aff;
+    background-color: var(--progress-blue);
 }

--- a/src/Pages/newMobilePaneIosFrame.html
+++ b/src/Pages/newMobilePaneIosFrame.html
@@ -3,77 +3,65 @@
 <head>
     <meta charset="UTF-8">
     <title>New Mobile Pane iOS Frame</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
 </head>
-<body class="framework7-root">
-    <div class="views tabs toolbar-through">
-        <div id="summary-view" class="view view-main tab active" data-page="summary">
-            <div class="pages">
-                <div data-page="summary" class="page">
-                    <div class="page-content">
-                        <div id="summary-content"></div>
-                        <div id="orig-headers-ui" class="list-block">
-                            <ul>
-                                <li class="accordion-item">
-                                    <a href="#" class="item-content item-link">
-                                        <div class="item-inner">
-                                            <div class="item-title">Original Headers</div>
+<body>
+    <div id="app" class="framework7-root">
+        <div class="view view-main view-init" data-master-detail-breakpoint="800">
+            <div class="page" data-name="home">
+                <div class="page-content">
+                    <div class="tabs">
+                        <div id="summary-view" class="tab tab-active">
+                            <div id="summary-content"></div>
+                            <div id="orig-headers-ui" class="list">
+                                <ul>
+                                    <li class="accordion-item">
+                                        <a href="#" class="item-content item-link">
+                                            <div class="item-inner">
+                                                <div class="item-title">Original Headers</div>
+                                            </div>
+                                        </a>
+                                        <div class="accordion-item-content">
+                                            <div class="code-box">
+                                                <pre><code id="original-headers"></code></pre>
+                                            </div>
                                         </div>
-                                    </a>
-                                    <div class="accordion-item-content">
-                                        <div class="code-box">
-                                            <pre><code id="original-headers"></code></pre>
-                                        </div>
-                                    </div>
-                                </li>
-                            </ul>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                        <div id="received-view" class="tab">
+                            <div id="received-content"></div>
+                        </div>
+                        <div id="antispam-view" class="tab">
+                            <div id="antispam-content"></div>
+                        </div>
+                        <div id="other-view" class="tab">
+                            <div id="other-content"></div>
                         </div>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div id="received-view" class="view tab" data-page="received">
-            <div class="pages">
-                <div data-page="received" class="page">
-                    <div id="received-content" class="page-content"></div>
-                </div>
-            </div>
-        </div>
-        <div id="antispam-view" class="view tab" data-page="antispam">
-            <div class="pages">
-                <div data-page="antispam" class="page">
-                    <div class="page-content">
-                        <div id="antispam-content"></div>
+
+                <div class="toolbar toolbar-bottom tabbar">
+                    <div class="toolbar-inner">
+                        <a href="#summary-view" class="tab-link tab-link-active" id="summary-btn">
+                            <i class="f7-icons">info</i>
+                            <span class="tabbar-label">Summary</span>
+                        </a>
+                        <a href="#received-view" class="tab-link">
+                            <i class="f7-icons">graph_square</i>
+                            <span class="tabbar-label">Received</span>
+                        </a>
+                        <a href="#antispam-view" class="tab-link">
+                            <i class="f7-icons">trash</i>
+                            <span class="tabbar-label">Antispam</span>
+                        </a>
+                        <a href="#other-view" class="tab-link">
+                            <i class="f7-icons">data</i>
+                            <span class="tabbar-label">Other</span>
+                        </a>
                     </div>
                 </div>
-            </div>
-        </div>
-        <div id="other-view" class="view tab" data-page="other">
-            <div class="pages">
-                <div data-page="other" class="page">
-                    <div class="page-content">
-                        <div id="other-content"></div>
-                    </div>
-                </div>
-            </div>
-        </div>
-        <div class="toolbar tabbar tabbar-labels">
-            <div class="toolbar-inner" role="toolbar">
-                <a href="#summary-view" class="tab-link active" role="button" id="summary-btn">
-                    <i class="f7-icons">info</i>
-                    <span class="tabbar-label">Summary</span>
-                </a>
-                <a href="#received-view" class="tab-link" role="button">
-                    <i class="f7-icons">graph_square</i>
-                    <span class="tabbar-label">Received</span>
-                </a>
-                <a href="#antispam-view" class="tab-link" role="button">
-                    <i class="f7-icons">trash</i>
-                    <span class="tabbar-label">Antispam</span>
-                </a>
-                <a href="#other-view" class="tab-link" role="button">
-                    <i class="f7-icons">data</i>
-                    <span class="tabbar-label">Other</span>
-                </a>
             </div>
         </div>
     </div>

--- a/src/Pages/newMobilePaneIosFrame.html
+++ b/src/Pages/newMobilePaneIosFrame.html
@@ -8,6 +8,7 @@
 <body>
     <div id="app" class="framework7-root">
         <div class="view view-main view-init" data-master-detail-breakpoint="800">
+            <div class="top-spacer"></div>
             <div class="page" data-name="home">
                 <div class="page-content">
                     <div class="tabs">
@@ -41,26 +42,26 @@
                         </div>
                     </div>
                 </div>
+            </div>
 
-                <div class="toolbar toolbar-bottom tabbar">
-                    <div class="toolbar-inner">
-                        <a href="#summary-view" class="tab-link tab-link-active" id="summary-btn">
-                            <i class="f7-icons">info</i>
-                            <span class="tabbar-label">Summary</span>
-                        </a>
-                        <a href="#received-view" class="tab-link">
-                            <i class="f7-icons">graph_square</i>
-                            <span class="tabbar-label">Received</span>
-                        </a>
-                        <a href="#antispam-view" class="tab-link">
-                            <i class="f7-icons">trash</i>
-                            <span class="tabbar-label">Antispam</span>
-                        </a>
-                        <a href="#other-view" class="tab-link">
-                            <i class="f7-icons">data</i>
-                            <span class="tabbar-label">Other</span>
-                        </a>
-                    </div>
+            <div id="bottom-toolbar" class="toolbar toolbar-bottom tabbar">
+                <div class="toolbar-inner">
+                    <a href="#summary-view" class="tab-link tab-link-active" id="summary-btn">
+                        <i class="f7-icons">info</i>
+                        <span class="tabbar-label">Summary</span>
+                    </a>
+                    <a href="#received-view" class="tab-link">
+                        <i class="f7-icons">graph_square</i>
+                        <span class="tabbar-label">Received</span>
+                    </a>
+                    <a href="#antispam-view" class="tab-link">
+                        <i class="f7-icons">trash</i>
+                        <span class="tabbar-label">Antispam</span>
+                    </a>
+                    <a href="#other-view" class="tab-link">
+                        <i class="f7-icons">data</i>
+                        <span class="tabbar-label">Other</span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/Scripts/framework7.ts
+++ b/src/Scripts/framework7.ts
@@ -1,5 +1,0 @@
-// Framework7 v8+ has full ES module support
-import Framework7 from "framework7";
-
-export { Framework7 };
-export default Framework7;

--- a/src/Scripts/framework7.ts
+++ b/src/Scripts/framework7.ts
@@ -1,9 +1,5 @@
-import "framework7";
-// Framework7 currently has full support for ES modules
-// However, we're using an old version of Framework7 which does not export
-// It instead adds Framework7 to window as a side effect
-// So we do a naked import and then export it from here so the rest of our code can treat
-// it as a regular module.
-// @ts-expect-error Framework doesn't exist, but it does - just do it
-// eslint-disable-next-line @typescript-eslint/naming-convention
-export const Framework7 = window.Framework7;
+// Framework7 v8+ has full ES module support
+import Framework7 from "framework7";
+
+export { Framework7 };
+export default Framework7;

--- a/src/Scripts/ui/domUtils.test.ts
+++ b/src/Scripts/ui/domUtils.test.ts
@@ -454,4 +454,250 @@ describe("DomUtils Class", () => {
             });
         });
     });
+
+    describe("Accessibility Methods", () => {
+        describe("focusableElements constant", () => {
+            test("contains expected focusable element selectors", () => {
+                expect(DomUtils.focusableElements).toBe("a, button, input, textarea, select, [tabindex]:not([tabindex=\"-1\"])");
+            });
+        });
+
+        describe("makeFocusableElementsNonTabbable", () => {
+            test("sets tabindex=-1 on focusable elements within containers", () => {
+                document.body.innerHTML = `
+                    <div class="container">
+                        <a href="#" id="link1">Link 1</a>
+                        <button id="btn1">Button 1</button>
+                        <input id="input1" type="text" />
+                        <textarea id="textarea1"></textarea>
+                        <select id="select1"><option>Option</option></select>
+                        <div tabindex="0" id="tabbable1">Tabbable Div</div>
+                    </div>
+                    <div class="other-container">
+                        <a href="#" id="link2">Link 2</a>
+                        <button id="btn2">Button 2</button>
+                    </div>
+                `;
+
+                DomUtils.makeFocusableElementsNonTabbable(".container");
+
+                // Elements in .container should have tabindex=-1
+                expect(document.getElementById("link1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("btn1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("input1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("textarea1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("select1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("tabbable1")?.getAttribute("tabindex")).toBe("-1");
+
+                // Elements in .other-container should not be affected
+                expect(document.getElementById("link2")?.getAttribute("tabindex")).toBeNull();
+                expect(document.getElementById("btn2")?.getAttribute("tabindex")).toBeNull();
+            });
+
+            test("handles elements that already have tabindex=-1", () => {
+                document.body.innerHTML = `
+                    <div class="container">
+                        <a href="#" tabindex="-1" id="already-non-tabbable">Already Non-tabbable</a>
+                        <button id="btn">Button</button>
+                    </div>
+                `;
+
+                DomUtils.makeFocusableElementsNonTabbable(".container");
+
+                expect(document.getElementById("already-non-tabbable")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("btn")?.getAttribute("tabindex")).toBe("-1");
+            });
+
+            test("handles multiple containers", () => {
+                document.body.innerHTML = `
+                    <div class="container">
+                        <button id="btn1">Button 1</button>
+                    </div>
+                    <div class="container">
+                        <button id="btn2">Button 2</button>
+                    </div>
+                `;
+
+                DomUtils.makeFocusableElementsNonTabbable(".container");
+
+                expect(document.getElementById("btn1")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("btn2")?.getAttribute("tabindex")).toBe("-1");
+            });
+
+            test("does nothing when no containers found", () => {
+                document.body.innerHTML = "<button id=\"btn\">Button</button>";
+
+                expect(() => {
+                    DomUtils.makeFocusableElementsNonTabbable(".nonexistent");
+                }).not.toThrow();
+
+                expect(document.getElementById("btn")?.getAttribute("tabindex")).toBeNull();
+            });
+        });
+
+        describe("restoreFocusableElements", () => {
+            test("removes tabindex=-1 from elements within containers", () => {
+                document.body.innerHTML = `
+                    <div class="container">
+                        <a href="#" tabindex="-1" id="link1">Link 1</a>
+                        <button tabindex="-1" id="btn1">Button 1</button>
+                        <input tabindex="-1" id="input1" type="text" />
+                        <div tabindex="5" id="custom-tabindex">Custom Tabindex</div>
+                    </div>
+                    <div class="other-container">
+                        <a href="#" tabindex="-1" id="link2">Link 2</a>
+                    </div>
+                `;
+
+                DomUtils.restoreFocusableElements(".container");
+
+                // Elements in .container with tabindex=-1 should have it removed
+                expect(document.getElementById("link1")?.hasAttribute("tabindex")).toBe(false);
+                expect(document.getElementById("btn1")?.hasAttribute("tabindex")).toBe(false);
+                expect(document.getElementById("input1")?.hasAttribute("tabindex")).toBe(false);
+
+                // Elements with other tabindex values should not be affected
+                expect(document.getElementById("custom-tabindex")?.getAttribute("tabindex")).toBe("5");
+
+                // Elements in other containers should not be affected
+                expect(document.getElementById("link2")?.getAttribute("tabindex")).toBe("-1");
+            });
+
+            test("handles multiple containers", () => {
+                document.body.innerHTML = `
+                    <div class="container">
+                        <button tabindex="-1" id="btn1">Button 1</button>
+                    </div>
+                    <div class="container">
+                        <button tabindex="-1" id="btn2">Button 2</button>
+                    </div>
+                `;
+
+                DomUtils.restoreFocusableElements(".container");
+
+                expect(document.getElementById("btn1")?.hasAttribute("tabindex")).toBe(false);
+                expect(document.getElementById("btn2")?.hasAttribute("tabindex")).toBe(false);
+            });
+
+            test("does nothing when no containers found", () => {
+                document.body.innerHTML = "<button tabindex=\"-1\" id=\"btn\">Button</button>";
+
+                expect(() => {
+                    DomUtils.restoreFocusableElements(".nonexistent");
+                }).not.toThrow();
+
+                expect(document.getElementById("btn")?.getAttribute("tabindex")).toBe("-1");
+            });
+        });
+
+        describe("setAccessibilityState", () => {
+            test("sets aria-hidden and visibility on elements", () => {
+                document.body.innerHTML = `
+                    <div class="content" id="content1">Content 1</div>
+                    <div class="content" id="content2">Content 2</div>
+                    <div class="other" id="other1">Other Content</div>
+                `;
+
+                DomUtils.setAccessibilityState(".content", true, false);
+
+                // Elements with .content class should be hidden
+                expect(document.getElementById("content1")?.getAttribute("aria-hidden")).toBe("true");
+                expect(document.getElementById("content1")?.style.visibility).toBe("hidden");
+                expect(document.getElementById("content2")?.getAttribute("aria-hidden")).toBe("true");
+                expect(document.getElementById("content2")?.style.visibility).toBe("hidden");
+
+                // Other elements should not be affected
+                expect(document.getElementById("other1")?.getAttribute("aria-hidden")).toBeNull();
+                expect(document.getElementById("other1")?.style.visibility).toBe("");
+            });
+
+            test("sets elements as visible and accessible", () => {
+                document.body.innerHTML = `
+                    <div class="content" id="content1" aria-hidden="true" style="visibility: hidden;">Content 1</div>
+                    <div class="content" id="content2" aria-hidden="true" style="visibility: hidden;">Content 2</div>
+                `;
+
+                DomUtils.setAccessibilityState(".content", false, true);
+
+                expect(document.getElementById("content1")?.getAttribute("aria-hidden")).toBe("false");
+                expect(document.getElementById("content1")?.style.visibility).toBe("visible");
+                expect(document.getElementById("content2")?.getAttribute("aria-hidden")).toBe("false");
+                expect(document.getElementById("content2")?.style.visibility).toBe("visible");
+            });
+
+            test("handles different combinations of hidden and visible states", () => {
+                document.body.innerHTML = `
+                    <div class="test" id="test1">Test 1</div>
+                    <div class="test" id="test2">Test 2</div>
+                `;
+
+                // Hidden from screen readers but visually visible
+                DomUtils.setAccessibilityState(".test", true, true);
+                expect(document.getElementById("test1")?.getAttribute("aria-hidden")).toBe("true");
+                expect(document.getElementById("test1")?.style.visibility).toBe("visible");
+
+                // Accessible to screen readers but visually hidden
+                DomUtils.setAccessibilityState(".test", false, false);
+                expect(document.getElementById("test1")?.getAttribute("aria-hidden")).toBe("false");
+                expect(document.getElementById("test1")?.style.visibility).toBe("hidden");
+            });
+
+            test("does nothing when no elements found", () => {
+                document.body.innerHTML = "<div id=\"test\">Test</div>";
+
+                expect(() => {
+                    DomUtils.setAccessibilityState(".nonexistent", true, false);
+                }).not.toThrow();
+
+                expect(document.getElementById("test")?.getAttribute("aria-hidden")).toBeNull();
+            });
+        });
+
+        describe("Integration tests for accordion accessibility", () => {
+            test("full accordion accessibility workflow", () => {
+                document.body.innerHTML = `
+                    <div class="accordion-item">
+                        <div class="accordion-item-content">
+                            <a href="#" id="link">Link</a>
+                            <button id="button">Button</button>
+                            <input id="input" type="text" />
+                        </div>
+                    </div>
+                    <div class="accordion-item accordion-item-expanded">
+                        <div class="accordion-item-content">
+                            <a href="#" id="expanded-link">Expanded Link</a>
+                            <button id="expanded-button">Expanded Button</button>
+                        </div>
+                    </div>
+                `;
+
+                // Initial state: make collapsed content non-accessible
+                const collapsedSelector = ".accordion-item:not(.accordion-item-expanded) .accordion-item-content";
+                DomUtils.setAccessibilityState(collapsedSelector, true, false);
+                DomUtils.makeFocusableElementsNonTabbable(collapsedSelector);
+
+                // Check collapsed accordion content is properly hidden
+                const collapsedContent = document.querySelector(".accordion-item:not(.accordion-item-expanded) .accordion-item-content") as HTMLElement;
+                expect(collapsedContent.getAttribute("aria-hidden")).toBe("true");
+                expect(collapsedContent.style.visibility).toBe("hidden");
+                expect(document.getElementById("link")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("button")?.getAttribute("tabindex")).toBe("-1");
+                expect(document.getElementById("input")?.getAttribute("tabindex")).toBe("-1");
+
+                // Check expanded accordion content is not affected
+                expect(document.getElementById("expanded-link")?.getAttribute("tabindex")).toBeNull();
+                expect(document.getElementById("expanded-button")?.getAttribute("tabindex")).toBeNull();
+
+                // Simulate accordion opening: restore accessibility
+                const expandedContent = document.querySelector(".accordion-item-expanded .accordion-item-content") as HTMLElement;
+                expandedContent.setAttribute("aria-hidden", "false");
+                expandedContent.style.visibility = "visible";
+                DomUtils.restoreFocusableElements(".accordion-item-expanded .accordion-item-content");
+
+                // All elements should still work as expected
+                expect(document.getElementById("expanded-link")?.getAttribute("tabindex")).toBeNull();
+                expect(document.getElementById("expanded-button")?.getAttribute("tabindex")).toBeNull();
+            });
+        });
+    });
 });

--- a/src/Scripts/ui/domUtils.ts
+++ b/src/Scripts/ui/domUtils.ts
@@ -132,4 +132,51 @@ export class DomUtils {
             element.setAttribute(attribute, value);
         }
     }
+
+    /**
+     * Common focusable element selector
+     */
+    static readonly focusableElements = "a, button, input, textarea, select, [tabindex]:not([tabindex=\"-1\"])";
+
+    /**
+     * Make elements non-tabbable by setting tabindex to -1
+     * @param selector CSS selector string
+     */
+    static makeFocusableElementsNonTabbable(selector: string): void {
+        const elements = this.getElements(selector);
+        elements.forEach(container => {
+            const focusableElements = container.querySelectorAll(this.focusableElements);
+            focusableElements.forEach((el) => {
+                (el as HTMLElement).setAttribute("tabindex", "-1");
+            });
+        });
+    }
+
+    /**
+     * Restore tabbing by removing tabindex=-1 from elements
+     * @param selector CSS selector string
+     */
+    static restoreFocusableElements(selector: string): void {
+        const elements = this.getElements(selector);
+        elements.forEach(container => {
+            const focusableElements = container.querySelectorAll("[tabindex=\"-1\"]");
+            focusableElements.forEach((el) => {
+                (el as HTMLElement).removeAttribute("tabindex");
+            });
+        });
+    }
+
+    /**
+     * Set accessibility attributes on elements
+     * @param selector CSS selector string
+     * @param hidden Whether elements should be hidden from screen readers
+     * @param visible Whether elements should be visible
+     */
+    static setAccessibilityState(selector: string, hidden: boolean, visible: boolean): void {
+        const elements = this.getElements(selector);
+        elements.forEach(element => {
+            element.setAttribute("aria-hidden", hidden.toString());
+            element.style.visibility = visible ? "visible" : "hidden";
+        });
+    }
 }

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -11,7 +11,6 @@ import Popover from "framework7/components/popover";
 import Preloader from "framework7/components/preloader";
 import Progressbar from "framework7/components/progressbar";
 import Tabs from "framework7/components/tabs";
-import $ from "jquery";
 
 import { HeaderModel } from "../HeaderModel";
 import { mhaStrings } from "../mhaStrings";
@@ -351,37 +350,47 @@ function buildViews(headers: string): void {
     }
 
     // Build other view
-    const otherContent = $("#other-content");
+    const otherContent = document.getElementById("other-content")!;
 
     viewModel.otherHeaders.rows.forEach((row: OtherRow) => {
         if (row.value) {
-            const headerName = $("<div/>")
-                .addClass("block-title")
-                .text(row.header)
-                .appendTo(otherContent);
+            const headerName = document.createElement("div");
+            headerName.className = "block-title";
+            headerName.textContent = row.header;
+            otherContent.appendChild(headerName);
 
             if (row.url) {
-                headerName.empty();
+                headerName.innerHTML = "";
 
-                $($.parseHTML(row.url))
-                    .addClass("external")
-                    .appendTo(headerName);
+                // Parse HTML string and add to headerName
+                const tempDiv = document.createElement("div");
+                tempDiv.innerHTML = row.url;
+                while (tempDiv.firstChild) {
+                    const child = tempDiv.firstChild as HTMLElement;
+                    if (child.nodeType === Node.ELEMENT_NODE) {
+                        child.classList.add("external");
+                    }
+                    headerName.appendChild(child);
+                }
             }
-            else headerName.attr("tabindex", 0);
+            else {
+                headerName.setAttribute("tabindex", "0");
+            }
 
-            const contentBlock = $("<div/>")
-                .addClass("block")
-                .appendTo(otherContent);
+            const contentBlock = document.createElement("div");
+            contentBlock.className = "block";
+            otherContent.appendChild(contentBlock);
 
-            const headerVal = $("<div/>")
-                .addClass("code-box")
-                .appendTo(contentBlock);
+            const headerVal = document.createElement("div");
+            headerVal.className = "code-box";
+            contentBlock.appendChild(headerVal);
 
-            const pre = $("<pre/>").appendTo(headerVal);
+            const pre = document.createElement("pre");
+            headerVal.appendChild(pre);
 
-            $("<code/>")
-                .text(row.value)
-                .appendTo(pre);
+            const code = document.createElement("code");
+            code.textContent = row.value;
+            pre.appendChild(code);
         }
     });
 }

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -1,5 +1,4 @@
-import "framework7/dist/css/framework7.ios.min.css";
-import "framework7/dist/css/framework7.ios.colors.min.css";
+import "framework7/css";
 import "framework7-icons/css/framework7-icons.css";
 import "../../Content/newMobilePaneIosFrame.css";
 import dayjs from "dayjs";
@@ -7,6 +6,7 @@ import utc from "dayjs/plugin/utc";
 import $ from "jquery";
 
 import { Framework7 } from "../framework7";
+import type Framework7Instance from "framework7";
 import { HeaderModel } from "../HeaderModel";
 import { mhaStrings } from "../mhaStrings";
 import { Poster } from "../Poster";
@@ -18,7 +18,7 @@ import { SummaryRow } from "../row/SummaryRow";
 // This is the "new-mobile" UI rendered in newMobilePaneIosFrame.html
 
 // Framework7 app object
-let myApp: typeof Framework7 = null;
+let myApp: Framework7Instance | null = null;
 
 dayjs.extend(utc);
 
@@ -27,19 +27,20 @@ function postError(error: unknown, message: string): void {
 }
 
 function initializeFramework7(): void {
-    myApp = new Framework7();
+    myApp = new Framework7({
+        // App name
+        name: 'MHA',
+        // Set theme based on platform
+        theme: 'auto',
+    });
 
-    myApp.addView("#summary-view");
-    myApp.addView("#received-view");
-    myApp.addView("#antispam-view");
-    myApp.addView("#other-view");
     document.getElementById("summary-btn")!.focus();
 }
 
 function updateStatus(message: string): void {
     if (myApp) {
-        myApp.hidePreloader();
-        myApp.showPreloader(message);
+        myApp.preloader.hide();
+        myApp.preloader.show(message);
     }
 }
 
@@ -240,7 +241,9 @@ function buildViews(headers: string): void {
                     .appendTo(progress);
 
                 try {
-                    myApp.showProgressbar(".progress-wrap-" + i, row.percent);
+                    if (myApp && row.percent.value !== null) {
+                        myApp.progressbar.show(".progress-wrap-" + i, Number(row.percent.value));
+                    }
                 } catch (e) {
                     $("#original-headers").text(JSON.stringify(e));
                     return;
@@ -407,7 +410,7 @@ function renderItem(headers: string): void {
         observer.observe(accordion, { attributes: true });
     });
 
-    if (myApp) myApp.hidePreloader();
+    if (myApp) myApp.preloader.hide();
 }
 
 // Handles rendering of an error.
@@ -415,8 +418,8 @@ function renderItem(headers: string): void {
 function showError(error: unknown, message: string): void {
     console.error("Error:", error);
     if (myApp) {
-        myApp.hidePreloader();
-        myApp.alert(message, "An Error Occurred");
+        myApp.preloader.hide();
+        myApp.dialog.alert(message, "An Error Occurred");
     }
 }
 

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -45,7 +45,56 @@ function initializeFramework7(): void {
         preloaderMethods: myApp.preloader ? Object.keys(myApp.preloader) : "not available"
     });
 
+    // Set up tab switching functionality
+    setupTabSwitching();
+    
+    // Initialize tab visibility - hide all tabs except the active one
+    initializeTabVisibility();
+
     document.getElementById("summary-btn")!.focus();
+}
+
+function initializeTabVisibility(): void {
+    // Hide all tabs except the active one
+    document.querySelectorAll('.view.tab').forEach(tab => {
+        if (!tab.classList.contains('active')) {
+            (tab as HTMLElement).style.display = 'none';
+        }
+    });
+}
+
+function setupTabSwitching(): void {
+    // Add click handlers for tab buttons
+    document.querySelectorAll('.tab-link').forEach(tabLink => {
+        tabLink.addEventListener('click', function(this: Element, e: Event) {
+            e.preventDefault();
+            
+            const targetTab = this.getAttribute('href');
+            if (!targetTab) return;
+            
+            console.log('Tab clicked:', targetTab);
+            
+            // Remove active class from all tabs and tab links
+            document.querySelectorAll('.view.tab').forEach(tab => {
+                tab.classList.remove('active');
+                // Hide the tab
+                (tab as HTMLElement).style.display = 'none';
+            });
+            document.querySelectorAll('.tab-link').forEach(link => {
+                link.classList.remove('active');
+            });
+            
+            // Add active class to clicked tab link and corresponding tab
+            this.classList.add('active');
+            const targetTabElement = document.querySelector(targetTab);
+            if (targetTabElement) {
+                targetTabElement.classList.add('active');
+                // Show the tab
+                (targetTabElement as HTMLElement).style.display = 'block';
+                console.log('Activated tab:', targetTab);
+            }
+        });
+    });
 }
 
 function updateStatus(message: string): void {

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -55,10 +55,10 @@ function initializeFramework7(): void {
 }
 
 function initializeTabVisibility(): void {
-    // Hide all tabs except the active one
-    document.querySelectorAll('.view.tab').forEach(tab => {
-        if (!tab.classList.contains('active')) {
-            (tab as HTMLElement).style.display = 'none';
+    // Hide all tabs except the active one using CSS classes
+    document.querySelectorAll('.tab').forEach(tab => {
+        if (!tab.classList.contains('tab-active')) {
+            tab.classList.remove('tab-active');
         }
     });
 }
@@ -75,22 +75,18 @@ function setupTabSwitching(): void {
             console.log('Tab clicked:', targetTab);
             
             // Remove active class from all tabs and tab links
-            document.querySelectorAll('.view.tab').forEach(tab => {
-                tab.classList.remove('active');
-                // Hide the tab
-                (tab as HTMLElement).style.display = 'none';
+            document.querySelectorAll('.tab').forEach(tab => {
+                tab.classList.remove('tab-active');
             });
             document.querySelectorAll('.tab-link').forEach(link => {
-                link.classList.remove('active');
+                link.classList.remove('tab-link-active');
             });
             
             // Add active class to clicked tab link and corresponding tab
-            this.classList.add('active');
+            this.classList.add('tab-link-active');
             const targetTabElement = document.querySelector(targetTab);
             if (targetTabElement) {
-                targetTabElement.classList.add('active');
-                // Show the tab
-                (targetTabElement as HTMLElement).style.display = 'block';
+                targetTabElement.classList.add('tab-active');
                 console.log('Activated tab:', targetTab);
             }
         });

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -25,11 +25,39 @@ import { SummaryRow } from "../row/SummaryRow";
 
 // Framework7 app object
 let myApp: Framework7 | null = null;
+const popovers: object[] = [];
 
 dayjs.extend(utc);
 
 function postError(error: unknown, message: string): void {
     Poster.postMessageToParent("LogError", { error: JSON.stringify(error), message: message });
+}
+
+function initializePopovers(): void {
+    if (!myApp) return;
+
+    // Find all popover triggers and create Framework7 popovers
+    $(".popover-trigger").each(function() {
+        const trigger = $(this);
+        const popoverIndex = trigger.attr("data-popover-index");
+        const popoverEl = $(`.popover-${popoverIndex}`);
+
+        if (popoverEl.length > 0 && trigger[0] && popoverEl[0]) {
+            // Create Framework7 popover instance
+            const popover = myApp!.popover.create({
+                targetEl: trigger[0],
+                el: popoverEl[0],
+            });
+
+            popovers.push(popover);
+
+            // Add click handler
+            trigger.on("click", function(e) {
+                e.preventDefault();
+                popover.open();
+            });
+        }
+    });
 }
 
 function initializeFramework7(): void {
@@ -180,8 +208,8 @@ function buildViews(headers: string): void {
                 const timelineInner: JQuery<HTMLElement> = $("<div/>")
                     .addClass("timeline-item-inner")
                     .addClass("link")
-                    .addClass("open-popover")
-                    .attr("data-popover", ".popover-" + i)
+                    .addClass("popover-trigger")
+                    .attr("data-popover-index", i.toString())
                     .appendTo(currentTimeEntry);
 
                 $("<div/>")
@@ -230,8 +258,8 @@ function buildViews(headers: string): void {
                 const timelineInner: JQuery<HTMLElement> = $("<div/>")
                     .addClass("timeline-item-inner")
                     .addClass("link")
-                    .addClass("open-popover")
-                    .attr("data-popover", ".popover-" + i)
+                    .addClass("popover-trigger")
+                    .attr("data-popover-index", i.toString())
                     .appendTo(currentTimeEntry);
 
                 $("<div/>")
@@ -310,6 +338,9 @@ function buildViews(headers: string): void {
         $("<div/>")
             .addClass("timeline-item-divider")
             .appendTo(endTimelineItem);
+
+        // Initialize Framework7 popovers
+        initializePopovers();
     }
 
     // Build antispam view

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -3,10 +3,11 @@ import "framework7-icons/css/framework7-icons.css";
 import "../../Content/newMobilePaneIosFrame.css";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
+import Framework7 from "framework7";
+import Preloader from "framework7/components/preloader";
+import Dialog from "framework7/components/dialog";
 import $ from "jquery";
 
-import { Framework7 } from "../framework7";
-import type Framework7Instance from "framework7";
 import { HeaderModel } from "../HeaderModel";
 import { mhaStrings } from "../mhaStrings";
 import { Poster } from "../Poster";
@@ -18,7 +19,7 @@ import { SummaryRow } from "../row/SummaryRow";
 // This is the "new-mobile" UI rendered in newMobilePaneIosFrame.html
 
 // Framework7 app object
-let myApp: Framework7Instance | null = null;
+let myApp: Framework7 | null = null;
 
 dayjs.extend(utc);
 
@@ -27,18 +28,28 @@ function postError(error: unknown, message: string): void {
 }
 
 function initializeFramework7(): void {
+    // Install Framework7 components
+    Framework7.use([Preloader, Dialog]);
+    
     myApp = new Framework7({
         // App name
-        name: 'MHA',
+        name: "MHA",
         // Set theme based on platform
-        theme: 'auto',
+        theme: "auto",
+    });
+
+    // Verify components are available
+    console.log("Framework7 initialized:", {
+        hasPreloader: !!myApp.preloader,
+        hasDialog: !!myApp.dialog,
+        preloaderMethods: myApp.preloader ? Object.keys(myApp.preloader) : "not available"
     });
 
     document.getElementById("summary-btn")!.focus();
 }
 
 function updateStatus(message: string): void {
-    if (myApp) {
+    if (myApp && myApp.preloader) {
         myApp.preloader.hide();
         myApp.preloader.show(message);
     }
@@ -49,7 +60,7 @@ function addCalloutEntry(name: string, value: string | number | null, parent: JQ
         $("<p/>")
             .addClass("wrap-line")
             .html("<strong>" + name + ": </strong>" + value)
-            .appendTo(parent);
+            .appendTo(parent); 
     }
 }
 
@@ -417,9 +428,14 @@ function renderItem(headers: string): void {
 // Does not log the error - caller is responsible for calling PostError
 function showError(error: unknown, message: string): void {
     console.error("Error:", error);
-    if (myApp) {
+    if (myApp && myApp.preloader) {
         myApp.preloader.hide();
+    }
+    if (myApp && myApp.dialog) {
         myApp.dialog.alert(message, "An Error Occurred");
+    } else {
+        // Fallback to browser alert if Framework7 dialog is not available
+        alert(`An Error Occurred: ${message}`);
     }
 }
 

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -1,4 +1,5 @@
 import "framework7/css";
+import "framework7/css/bundle";
 import "framework7-icons/css/framework7-icons.css";
 import "../../Content/newMobilePaneIosFrame.css";
 import dayjs from "dayjs";

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -140,59 +140,57 @@ function buildViews(headers: string): void {
     }
 
     // Build received view
-    const receivedContent = $("#received-content");
+    const receivedContent = document.getElementById("received-content")!;
 
     if (viewModel.receivedHeaders.rows.length > 0) {
-        const timeline = $("<div/>")
-            .addClass("timeline")
-            .appendTo(receivedContent);
+        const timeline = document.createElement("div");
+        timeline.className = "timeline";
+        receivedContent.appendChild(timeline);
 
         let currentTime: dayjs.Dayjs = dayjs(viewModel.receivedHeaders.rows[0]?.dateNum.value).local();
-        let currentTimeEntry: JQuery<HTMLElement>;
+        let currentTimeEntry: HTMLElement;
 
         viewModel.receivedHeaders.rows.forEach((row: ReceivedRow, i: number) => {
             if (i === 0) {
-                const timelineItem: JQuery<HTMLElement> = $("<div/>")
-                    .addClass("timeline-item")
-                    .appendTo(timeline);
+                const timelineItem = document.createElement("div");
+                timelineItem.className = "timeline-item";
+                timeline.appendChild(timelineItem);
 
                 const timelineDate: string = currentTime.format("h:mm") + "<small>" + currentTime.format("A") + "</small>";
 
-                $("<div/>")
-                    .addClass("timeline-item-date")
-                    .html(timelineDate)
-                    .appendTo(timelineItem);
+                const timelineDateEl = document.createElement("div");
+                timelineDateEl.className = "timeline-item-date";
+                timelineDateEl.innerHTML = timelineDate;
+                timelineItem.appendChild(timelineDateEl);
 
-                $("<div/>")
-                    .addClass("timeline-item-divider")
-                    .appendTo(timelineItem);
+                const timelineDivider = document.createElement("div");
+                timelineDivider.className = "timeline-item-divider";
+                timelineItem.appendChild(timelineDivider);
 
-                currentTimeEntry = $("<div/>")
-                    .addClass("timeline-item-content")
-                    .appendTo(timelineItem);
+                currentTimeEntry = document.createElement("div");
+                currentTimeEntry.className = "timeline-item-content";
+                timelineItem.appendChild(currentTimeEntry);
 
                 // Add initial other rows
-                const timelineInner: JQuery<HTMLElement> = $("<div/>")
-                    .addClass("timeline-item-inner")
-                    .addClass("link")
-                    .addClass("popover-open")
-                    .attr("data-popover", ".popover-" + i)
-                    .appendTo(currentTimeEntry);
+                const timelineInner = document.createElement("div");
+                timelineInner.className = "timeline-item-inner link popover-open";
+                timelineInner.setAttribute("data-popover", ".popover-" + i);
+                currentTimeEntry.appendChild(timelineInner);
 
-                $("<div/>")
-                    .addClass("timeline-item-time")
-                    .text(currentTime.format("h:mm:ss"))
-                    .appendTo(timelineInner);
+                const timelineTime = document.createElement("div");
+                timelineTime.className = "timeline-item-time";
+                timelineTime.textContent = currentTime.format("h:mm:ss");
+                timelineInner.appendChild(timelineTime);
 
-                $("<div/>")
-                    .addClass("timeline-item-subtitle")
-                    .html("<strong>From: </strong>" + row.from)
-                    .appendTo(timelineInner);
+                const timelineSubtitle = document.createElement("div");
+                timelineSubtitle.className = "timeline-item-subtitle";
+                timelineSubtitle.innerHTML = "<strong>From: </strong>" + row.from;
+                timelineInner.appendChild(timelineSubtitle);
 
-                $("<div/>")
-                    .addClass("timeline-item-text")
-                    .html("<strong>To: </strong>" + row.by)
-                    .appendTo(timelineInner);
+                const timelineText = document.createElement("div");
+                timelineText.className = "timeline-item-text";
+                timelineText.innerHTML = "<strong>To: </strong>" + row.by;
+                timelineInner.appendChild(timelineText);
             } else {
                 // Determine if new timeline item is needed
                 const entryTime = dayjs(row.dateNum.value).local();
@@ -201,55 +199,53 @@ function buildViews(headers: string): void {
                     // Into a new minute, create a new timeline item
                     currentTime = entryTime;
 
-                    const timelineItem: JQuery<HTMLElement> = $("<div/>")
-                        .addClass("timeline-item")
-                        .appendTo(timeline);
+                    const timelineItem = document.createElement("div");
+                    timelineItem.className = "timeline-item";
+                    timeline.appendChild(timelineItem);
 
                     const timelineDate: string = currentTime.format("h:mm") + "<small>" + currentTime.format("A") + "</small>";
-                    $("<div/>")
-                        .addClass("timeline-item-date")
-                        .html(timelineDate)
-                        .appendTo(timelineItem);
+                    const timelineDateEl = document.createElement("div");
+                    timelineDateEl.className = "timeline-item-date";
+                    timelineDateEl.innerHTML = timelineDate;
+                    timelineItem.appendChild(timelineDateEl);
 
-                    $("<div/>")
-                        .addClass("timeline-item-divider")
-                        .appendTo(timelineItem);
+                    const timelineDivider = document.createElement("div");
+                    timelineDivider.className = "timeline-item-divider";
+                    timelineItem.appendChild(timelineDivider);
 
-                    currentTimeEntry = $("<div/>")
-                        .addClass("timeline-item-content")
-                        .appendTo(timelineItem);
+                    currentTimeEntry = document.createElement("div");
+                    currentTimeEntry.className = "timeline-item-content";
+                    timelineItem.appendChild(currentTimeEntry);
 
                 }
 
                 // Add additional rows
-                const timelineInner: JQuery<HTMLElement> = $("<div/>")
-                    .addClass("timeline-item-inner")
-                    .addClass("link")
-                    .addClass("popover-open")
-                    .attr("data-popover", ".popover-" + i)
-                    .appendTo(currentTimeEntry);
+                const timelineInner = document.createElement("div");
+                timelineInner.className = "timeline-item-inner link popover-open";
+                timelineInner.setAttribute("data-popover", ".popover-" + i);
+                currentTimeEntry.appendChild(timelineInner);
 
-                $("<div/>")
-                    .addClass("timeline-item-time")
-                    .text(entryTime.format("h:mm:ss"))
-                    .appendTo(timelineInner);
+                const timelineTime = document.createElement("div");
+                timelineTime.className = "timeline-item-time";
+                timelineTime.textContent = entryTime.format("h:mm:ss");
+                timelineInner.appendChild(timelineTime);
 
-                $("<div/>")
-                    .addClass("timeline-item-subtitle")
-                    .html("<strong>To: </strong>" + row.by)
-                    .appendTo(timelineInner);
+                const timelineSubtitle = document.createElement("div");
+                timelineSubtitle.className = "timeline-item-subtitle";
+                timelineSubtitle.innerHTML = "<strong>To: </strong>" + row.by;
+                timelineInner.appendChild(timelineSubtitle);
 
-                const progress = $("<div/>")
-                    .addClass("timeline-item-text")
-                    .appendTo(timelineInner);
+                const progress = document.createElement("div");
+                progress.className = "timeline-item-text";
+                timelineInner.appendChild(progress);
 
-                $("<p/>")
-                    .text(row.delay.value !== null ? row.delay.value : "")
-                    .appendTo(progress);
+                const delayText = document.createElement("p");
+                delayText.textContent = row.delay.value !== null ? String(row.delay.value) : "";
+                progress.appendChild(delayText);
 
-                $("<p/>")
-                    .addClass("progress-wrap-" + i)
-                    .appendTo(progress);
+                const progressWrap = document.createElement("p");
+                progressWrap.className = "progress-wrap-" + i;
+                progress.appendChild(progressWrap);
 
                 try {
                     if (myApp && row.percent.value !== null) {
@@ -291,20 +287,20 @@ function buildViews(headers: string): void {
 
         // Add a final empty timeline item to extend
         // timeline
-        const endTimelineItem = $("<div/>")
-            .addClass("timeline-item")
-            .appendTo(timeline);
+        const endTimelineItem = document.createElement("div");
+        endTimelineItem.className = "timeline-item";
+        timeline.appendChild(endTimelineItem);
 
         currentTime.add(1, "m");
         const endTimelineDate = currentTime.format("h:mm") + "<small>" + currentTime.format("A") + "</small>";
-        $("<div/>")
-            .addClass("timeline-item-date")
-            .html(endTimelineDate)
-            .appendTo(endTimelineItem);
+        const endTimelineDateEl = document.createElement("div");
+        endTimelineDateEl.className = "timeline-item-date";
+        endTimelineDateEl.innerHTML = endTimelineDate;
+        endTimelineItem.appendChild(endTimelineDateEl);
 
-        $("<div/>")
-            .addClass("timeline-item-divider")
-            .appendTo(endTimelineItem);
+        const endTimelineDivider = document.createElement("div");
+        endTimelineDivider.className = "timeline-item-divider";
+        endTimelineItem.appendChild(endTimelineDivider);
     }
 
     // Build antispam view

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -4,6 +4,7 @@ import "../../Content/newMobilePaneIosFrame.css";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import Framework7 from "framework7";
+import Accordion from "framework7/components/accordion";
 import Dialog from "framework7/components/dialog";
 import Preloader from "framework7/components/preloader";
 import $ from "jquery";
@@ -29,7 +30,7 @@ function postError(error: unknown, message: string): void {
 
 function initializeFramework7(): void {
     // Install Framework7 components
-    Framework7.use([Preloader, Dialog]);
+    Framework7.use([Preloader, Dialog, Accordion]);
 
     myApp = new Framework7({
         // App name

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -137,7 +137,7 @@ function addSpamReportRow(spamRow: Row, parent: JQuery<HTMLElement>) {
             .appendTo(item);
 
         const contentBlock = $("<div/>")
-            .addClass("content-block")
+            .addClass("block")
             .appendTo(itemContent);
 
         const linkWrap = $("<p/>")
@@ -159,12 +159,12 @@ function buildViews(headers: string): void {
     viewModel.summary.rows.forEach((row: SummaryRow) => {
         if (row.value) {
             $("<div/>")
-                .addClass("content-block-title")
+                .addClass("block-title")
                 .text(row.label)
                 .appendTo(summaryContent);
 
             const contentBlock = $("<div/>")
-                .addClass("content-block")
+                .addClass("block")
                 .appendTo(summaryContent);
 
             const headerVal = $("<div/>")
@@ -321,7 +321,7 @@ function buildViews(headers: string): void {
                 .appendTo(popover);
 
             const popoverContent = $("<div/>")
-                .addClass("content-block")
+                .addClass("block")
                 .appendTo(popoverInner);
 
             addCalloutEntry("From", row.from.value, popoverContent);
@@ -358,12 +358,12 @@ function buildViews(headers: string): void {
     // Forefront
     if (viewModel.forefrontAntiSpamReport.rows.length > 0) {
         $("<div/>")
-            .addClass("content-block-title")
+            .addClass("block-title")
             .text("Forefront Antispam Report")
             .appendTo(antispamContent);
 
         const list: JQuery<HTMLElement> = $("<div/>")
-            .addClass("list-block")
+            .addClass("list")
             .addClass("accordion-list")
             .appendTo(antispamContent);
 
@@ -378,12 +378,12 @@ function buildViews(headers: string): void {
     // Microsoft
     if (viewModel.antiSpamReport.rows.length > 0) {
         $("<div/>")
-            .addClass("content-block-title")
+            .addClass("block-title")
             .text("Microsoft Antispam Report")
             .appendTo(antispamContent);
 
         const list: JQuery<HTMLElement> = $("<div/>")
-            .addClass("list-block")
+            .addClass("list")
             .addClass("accordion-list")
             .appendTo(antispamContent);
 
@@ -401,7 +401,7 @@ function buildViews(headers: string): void {
     viewModel.otherHeaders.rows.forEach((row: OtherRow) => {
         if (row.value) {
             const headerName = $("<div/>")
-                .addClass("content-block-title")
+                .addClass("block-title")
                 .text(row.header)
                 .appendTo(otherContent);
 
@@ -415,7 +415,7 @@ function buildViews(headers: string): void {
             else headerName.attr("tabindex", 0);
 
             const contentBlock = $("<div/>")
-                .addClass("content-block")
+                .addClass("block")
                 .appendTo(otherContent);
 
             const headerVal = $("<div/>")

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -10,6 +10,7 @@ import Dialog from "framework7/components/dialog";
 import Popover from "framework7/components/popover";
 import Preloader from "framework7/components/preloader";
 import Progressbar from "framework7/components/progressbar";
+import Tabs from "framework7/components/tabs";
 import $ from "jquery";
 
 import { HeaderModel } from "../HeaderModel";
@@ -33,7 +34,7 @@ function postError(error: unknown, message: string): void {
 
 function initializeFramework7(): void {
     // Install Framework7 components
-    Framework7.use([Preloader, Dialog, Accordion, Progressbar, Popover]);
+    Framework7.use([Preloader, Dialog, Accordion, Progressbar, Popover, Tabs]);
 
     myApp = new Framework7({
         // App name
@@ -49,52 +50,7 @@ function initializeFramework7(): void {
         preloaderMethods: myApp.preloader ? Object.keys(myApp.preloader) : "not available"
     });
 
-    // Set up tab switching functionality
-    setupTabSwitching();
-
-    // Initialize tab visibility - hide all tabs except the active one
-    initializeTabVisibility();
-
     document.getElementById("summary-btn")!.focus();
-}
-
-function initializeTabVisibility(): void {
-    // Hide all tabs except the active one using CSS classes
-    document.querySelectorAll(".tab").forEach(tab => {
-        if (!tab.classList.contains("tab-active")) {
-            tab.classList.remove("tab-active");
-        }
-    });
-}
-
-function setupTabSwitching(): void {
-    // Add click handlers for tab buttons
-    document.querySelectorAll(".tab-link").forEach(tabLink => {
-        tabLink.addEventListener("click", function(this: Element, e: Event) {
-            e.preventDefault();
-
-            const targetTab = this.getAttribute("href");
-            if (!targetTab) return;
-
-            console.log("Tab clicked:", targetTab);
-
-            // Remove active class from all tabs and tab links
-            document.querySelectorAll(".tab").forEach(tab => {
-                tab.classList.remove("tab-active");
-            });
-            document.querySelectorAll(".tab-link").forEach(link => {
-                link.classList.remove("tab-link-active");
-            });
-
-            // Add active class to clicked tab link and corresponding tab
-            this.classList.add("tab-link-active");
-            const targetTabElement = document.querySelector(targetTab);
-            if (targetTabElement) {
-                targetTabElement.classList.add("tab-active");
-                console.log("Activated tab:", targetTab);
-            }
-        });
-    });
 }
 
 function updateStatus(message: string): void {

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -25,39 +25,11 @@ import { SummaryRow } from "../row/SummaryRow";
 
 // Framework7 app object
 let myApp: Framework7 | null = null;
-const popovers: object[] = [];
 
 dayjs.extend(utc);
 
 function postError(error: unknown, message: string): void {
     Poster.postMessageToParent("LogError", { error: JSON.stringify(error), message: message });
-}
-
-function initializePopovers(): void {
-    if (!myApp) return;
-
-    // Find all popover triggers and create Framework7 popovers
-    $(".popover-trigger").each(function() {
-        const trigger = $(this);
-        const popoverIndex = trigger.attr("data-popover-index");
-        const popoverEl = $(`.popover-${popoverIndex}`);
-
-        if (popoverEl.length > 0 && trigger[0] && popoverEl[0]) {
-            // Create Framework7 popover instance
-            const popover = myApp!.popover.create({
-                targetEl: trigger[0],
-                el: popoverEl[0],
-            });
-
-            popovers.push(popover);
-
-            // Add click handler
-            trigger.on("click", function(e) {
-                e.preventDefault();
-                popover.open();
-            });
-        }
-    });
 }
 
 function initializeFramework7(): void {
@@ -208,8 +180,8 @@ function buildViews(headers: string): void {
                 const timelineInner: JQuery<HTMLElement> = $("<div/>")
                     .addClass("timeline-item-inner")
                     .addClass("link")
-                    .addClass("popover-trigger")
-                    .attr("data-popover-index", i.toString())
+                    .addClass("popover-open")
+                    .attr("data-popover", ".popover-" + i)
                     .appendTo(currentTimeEntry);
 
                 $("<div/>")
@@ -258,8 +230,8 @@ function buildViews(headers: string): void {
                 const timelineInner: JQuery<HTMLElement> = $("<div/>")
                     .addClass("timeline-item-inner")
                     .addClass("link")
-                    .addClass("popover-trigger")
-                    .attr("data-popover-index", i.toString())
+                    .addClass("popover-open")
+                    .attr("data-popover", ".popover-" + i)
                     .appendTo(currentTimeEntry);
 
                 $("<div/>")
@@ -338,9 +310,6 @@ function buildViews(headers: string): void {
         $("<div/>")
             .addClass("timeline-item-divider")
             .appendTo(endTimelineItem);
-
-        // Initialize Framework7 popovers
-        initializePopovers();
     }
 
     // Build antispam view

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -4,8 +4,8 @@ import "../../Content/newMobilePaneIosFrame.css";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import Framework7 from "framework7";
-import Preloader from "framework7/components/preloader";
 import Dialog from "framework7/components/dialog";
+import Preloader from "framework7/components/preloader";
 import $ from "jquery";
 
 import { HeaderModel } from "../HeaderModel";
@@ -30,7 +30,7 @@ function postError(error: unknown, message: string): void {
 function initializeFramework7(): void {
     // Install Framework7 components
     Framework7.use([Preloader, Dialog]);
-    
+
     myApp = new Framework7({
         // App name
         name: "MHA",
@@ -47,7 +47,7 @@ function initializeFramework7(): void {
 
     // Set up tab switching functionality
     setupTabSwitching();
-    
+
     // Initialize tab visibility - hide all tabs except the active one
     initializeTabVisibility();
 
@@ -56,38 +56,38 @@ function initializeFramework7(): void {
 
 function initializeTabVisibility(): void {
     // Hide all tabs except the active one using CSS classes
-    document.querySelectorAll('.tab').forEach(tab => {
-        if (!tab.classList.contains('tab-active')) {
-            tab.classList.remove('tab-active');
+    document.querySelectorAll(".tab").forEach(tab => {
+        if (!tab.classList.contains("tab-active")) {
+            tab.classList.remove("tab-active");
         }
     });
 }
 
 function setupTabSwitching(): void {
     // Add click handlers for tab buttons
-    document.querySelectorAll('.tab-link').forEach(tabLink => {
-        tabLink.addEventListener('click', function(this: Element, e: Event) {
+    document.querySelectorAll(".tab-link").forEach(tabLink => {
+        tabLink.addEventListener("click", function(this: Element, e: Event) {
             e.preventDefault();
-            
-            const targetTab = this.getAttribute('href');
+
+            const targetTab = this.getAttribute("href");
             if (!targetTab) return;
-            
-            console.log('Tab clicked:', targetTab);
-            
+
+            console.log("Tab clicked:", targetTab);
+
             // Remove active class from all tabs and tab links
-            document.querySelectorAll('.tab').forEach(tab => {
-                tab.classList.remove('tab-active');
+            document.querySelectorAll(".tab").forEach(tab => {
+                tab.classList.remove("tab-active");
             });
-            document.querySelectorAll('.tab-link').forEach(link => {
-                link.classList.remove('tab-link-active');
+            document.querySelectorAll(".tab-link").forEach(link => {
+                link.classList.remove("tab-link-active");
             });
-            
+
             // Add active class to clicked tab link and corresponding tab
-            this.classList.add('tab-link-active');
+            this.classList.add("tab-link-active");
             const targetTabElement = document.querySelector(targetTab);
             if (targetTabElement) {
-                targetTabElement.classList.add('tab-active');
-                console.log('Activated tab:', targetTab);
+                targetTabElement.classList.add("tab-active");
+                console.log("Activated tab:", targetTab);
             }
         });
     });
@@ -105,7 +105,7 @@ function addCalloutEntry(name: string, value: string | number | null, parent: JQ
         $("<p/>")
             .addClass("wrap-line")
             .html("<strong>" + name + ": </strong>" + value)
-            .appendTo(parent); 
+            .appendTo(parent);
     }
 }
 

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -63,44 +63,50 @@ function addCalloutEntry(name: string, value: string | number | null, parent: HT
     }
 }
 
-function addSpamReportRow(spamRow: Row, parent: JQuery<HTMLElement>) {
+function addSpamReportRow(spamRow: Row, parent: HTMLElement) {
     if (spamRow.value) {
-        const item = $("<li/>")
-            .addClass("accordion-item")
-            .appendTo(parent);
+        const item = document.createElement("li");
+        item.className = "accordion-item";
+        parent.appendChild(item);
 
-        const link = $("<a/>")
-            .addClass("item-content")
-            .addClass("item-link")
-            .attr("role", "button") // Fix for the Bug 1691252- To announce link item as role button
-            .attr("href", "#")
-            .appendTo(item);
+        const link = document.createElement("a");
+        link.className = "item-content item-link";
+        link.setAttribute("role", "button"); // Fix for the Bug 1691252- To announce link item as role button
+        link.setAttribute("href", "#");
+        item.appendChild(link);
 
-        const innerItem = $("<div/>")
-            .addClass("item-inner")
-            .appendTo(link);
+        const innerItem = document.createElement("div");
+        innerItem.className = "item-inner";
+        link.appendChild(innerItem);
 
-        $("<div/>")
-            .addClass("item-title")
-            .text(spamRow.label)
-            .attr("id", spamRow.id)
-            .appendTo(innerItem);
+        const itemTitle = document.createElement("div");
+        itemTitle.className = "item-title";
+        itemTitle.textContent = spamRow.label;
+        itemTitle.setAttribute("id", spamRow.id);
+        innerItem.appendChild(itemTitle);
 
-        const itemContent = $("<div/>")
-            .addClass("accordion-item-content")
-            .appendTo(item);
+        const itemContent = document.createElement("div");
+        itemContent.className = "accordion-item-content";
+        item.appendChild(itemContent);
 
-        const contentBlock = $("<div/>")
-            .addClass("block")
-            .appendTo(itemContent);
+        const contentBlock = document.createElement("div");
+        contentBlock.className = "block";
+        itemContent.appendChild(contentBlock);
 
-        const linkWrap = $("<p/>")
-            .attr("aria-labelledby", spamRow.id)
-            .appendTo(contentBlock);
+        const linkWrap = document.createElement("p");
+        linkWrap.setAttribute("aria-labelledby", spamRow.id);
+        contentBlock.appendChild(linkWrap);
 
-        $($.parseHTML(spamRow.valueUrl))
-            .addClass("external")
-            .appendTo(linkWrap);
+        // Parse HTML string and add to linkWrap
+        const tempDiv = document.createElement("div");
+        tempDiv.innerHTML = spamRow.valueUrl;
+        while (tempDiv.firstChild) {
+            const child = tempDiv.firstChild as HTMLElement;
+            if (child.nodeType === Node.ELEMENT_NODE) {
+                child.classList.add("external");
+            }
+            linkWrap.appendChild(child);
+        }
     }
 }
 
@@ -304,22 +310,21 @@ function buildViews(headers: string): void {
     }
 
     // Build antispam view
-    const antispamContent = $("#antispam-content");
+    const antispamContent = document.getElementById("antispam-content")!;
 
     // Forefront
     if (viewModel.forefrontAntiSpamReport.rows.length > 0) {
-        $("<div/>")
-            .addClass("block-title")
-            .text("Forefront Antispam Report")
-            .appendTo(antispamContent);
+        const blockTitle = document.createElement("div");
+        blockTitle.className = "block-title";
+        blockTitle.textContent = "Forefront Antispam Report";
+        antispamContent.appendChild(blockTitle);
 
-        const list: JQuery<HTMLElement> = $("<div/>")
-            .addClass("list")
-            .addClass("accordion-list")
-            .appendTo(antispamContent);
+        const list = document.createElement("div");
+        list.className = "list accordion-list";
+        antispamContent.appendChild(list);
 
-        const ul: JQuery<HTMLElement> = $("<ul/>")
-            .appendTo(list);
+        const ul = document.createElement("ul");
+        list.appendChild(ul);
 
         viewModel.forefrontAntiSpamReport.rows.forEach((row: Row) => {
             addSpamReportRow(row, ul);
@@ -328,18 +333,17 @@ function buildViews(headers: string): void {
 
     // Microsoft
     if (viewModel.antiSpamReport.rows.length > 0) {
-        $("<div/>")
-            .addClass("block-title")
-            .text("Microsoft Antispam Report")
-            .appendTo(antispamContent);
+        const blockTitle = document.createElement("div");
+        blockTitle.className = "block-title";
+        blockTitle.textContent = "Microsoft Antispam Report";
+        antispamContent.appendChild(blockTitle);
 
-        const list: JQuery<HTMLElement> = $("<div/>")
-            .addClass("list")
-            .addClass("accordion-list")
-            .appendTo(antispamContent);
+        const list = document.createElement("div");
+        list.className = "list accordion-list";
+        antispamContent.appendChild(list);
 
-        const ul: JQuery<HTMLElement> = $("<ul/>")
-            .appendTo(list);
+        const ul = document.createElement("ul");
+        list.appendChild(ul);
 
         viewModel.antiSpamReport.rows.forEach((row: Row) => {
             addSpamReportRow(row, ul);

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -43,13 +43,6 @@ function initializeFramework7(): void {
         theme: "auto",
     });
 
-    // Verify components are available
-    console.log("Framework7 initialized:", {
-        hasPreloader: !!myApp.preloader,
-        hasDialog: !!myApp.dialog,
-        preloaderMethods: myApp.preloader ? Object.keys(myApp.preloader) : "not available"
-    });
-
     document.getElementById("summary-btn")!.focus();
 }
 

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -54,12 +54,12 @@ function updateStatus(message: string): void {
     }
 }
 
-function addCalloutEntry(name: string, value: string | number | null, parent: JQuery<HTMLElement>): void {
+function addCalloutEntry(name: string, value: string | number | null, parent: HTMLElement): void {
     if (value) {
-        $("<p/>")
-            .addClass("wrap-line")
-            .html("<strong>" + name + ": </strong>" + value)
-            .appendTo(parent);
+        const p = document.createElement("p");
+        p.className = "wrap-line";
+        p.innerHTML = "<strong>" + name + ": </strong>" + value;
+        parent.appendChild(p);
     }
 }
 
@@ -108,28 +108,29 @@ function buildViews(headers: string): void {
     const viewModel = new HeaderModel(headers);
 
     // Build summary view
-    const summaryContent = $("#summary-content");
+    const summaryContent = document.getElementById("summary-content")!;
 
     viewModel.summary.rows.forEach((row: SummaryRow) => {
         if (row.value) {
-            $("<div/>")
-                .addClass("block-title")
-                .text(row.label)
-                .appendTo(summaryContent);
+            const blockTitle = document.createElement("div");
+            blockTitle.className = "block-title";
+            blockTitle.textContent = row.label;
+            summaryContent.appendChild(blockTitle);
 
-            const contentBlock = $("<div/>")
-                .addClass("block")
-                .appendTo(summaryContent);
+            const contentBlock = document.createElement("div");
+            contentBlock.className = "block";
+            summaryContent.appendChild(contentBlock);
 
-            const headerVal = $("<div/>")
-                .addClass("code-box")
-                .appendTo(contentBlock);
+            const headerVal = document.createElement("div");
+            headerVal.className = "code-box";
+            contentBlock.appendChild(headerVal);
 
-            const pre = $("<pre/>").appendTo(headerVal);
+            const pre = document.createElement("pre");
+            headerVal.appendChild(pre);
 
-            $("<code/>")
-                .text(row.value)
-                .appendTo(pre);
+            const code = document.createElement("code");
+            code.textContent = row.value;
+            pre.appendChild(code);
         }
     });
 
@@ -261,22 +262,22 @@ function buildViews(headers: string): void {
             }
 
             // popover
-            const popover = $("<div/>")
-                .addClass("popover")
-                .addClass("popover-" + i)
-                .appendTo(receivedContent);
+            const receivedContentEl = document.getElementById("received-content")!;
+            const popover = document.createElement("div");
+            popover.className = "popover popover-" + i;
+            receivedContentEl.appendChild(popover);
 
-            $("<div/>")
-                .addClass("popover-angle")
-                .appendTo(popover);
+            const popoverAngle = document.createElement("div");
+            popoverAngle.className = "popover-angle";
+            popover.appendChild(popoverAngle);
 
-            const popoverInner = $("<div/>")
-                .addClass("popover-inner")
-                .appendTo(popover);
+            const popoverInner = document.createElement("div");
+            popoverInner.className = "popover-inner";
+            popover.appendChild(popoverInner);
 
-            const popoverContent = $("<div/>")
-                .addClass("block")
-                .appendTo(popoverInner);
+            const popoverContent = document.createElement("div");
+            popoverContent.className = "block";
+            popoverInner.appendChild(popoverContent);
 
             addCalloutEntry("From", row.from.value, popoverContent);
             addCalloutEntry("To", row.by.value, popoverContent);

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -6,6 +6,7 @@ import utc from "dayjs/plugin/utc";
 import Framework7 from "framework7";
 import Accordion from "framework7/components/accordion";
 import Dialog from "framework7/components/dialog";
+import Popover from "framework7/components/popover";
 import Preloader from "framework7/components/preloader";
 import Progressbar from "framework7/components/progressbar";
 import $ from "jquery";
@@ -31,7 +32,7 @@ function postError(error: unknown, message: string): void {
 
 function initializeFramework7(): void {
     // Install Framework7 components
-    Framework7.use([Preloader, Dialog, Accordion, Progressbar]);
+    Framework7.use([Preloader, Dialog, Accordion, Progressbar, Popover]);
 
     myApp = new Framework7({
         // App name

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -134,8 +134,8 @@ function buildViews(headers: string): void {
     });
 
     if (viewModel.originalHeaders) {
-        $("#original-headers").text(viewModel.originalHeaders);
-        $("#orig-headers-ui").show();
+        DomUtils.setText("#original-headers", viewModel.originalHeaders);
+        DomUtils.showElement("#orig-headers-ui");
     }
 
     // Build received view
@@ -255,7 +255,7 @@ function buildViews(headers: string): void {
                         myApp.progressbar.show(".progress-wrap-" + i, Number(row.percent.value));
                     }
                 } catch (e) {
-                    $("#original-headers").text(JSON.stringify(e));
+                    DomUtils.setText("#original-headers", JSON.stringify(e));
                     return;
                 }
             }
@@ -387,11 +387,11 @@ function buildViews(headers: string): void {
 
 function renderItem(headers: string): void {
     // Empty data
-    $("#summary-content").empty();
-    $("#received-content").empty();
-    $("#antispam-content").empty();
-    $("#other-content").empty();
-    $("#original-headers").empty();
+    DomUtils.clearElement("#summary-content");
+    DomUtils.clearElement("#received-content");
+    DomUtils.clearElement("#antispam-content");
+    DomUtils.clearElement("#other-content");
+    DomUtils.clearElement("#original-headers");
 
     updateStatus(mhaStrings.mhaLoading);
 
@@ -471,7 +471,7 @@ function eventListener(event: MessageEvent): void {
     }
 }
 
-$(function() {
+document.addEventListener("DOMContentLoaded", function() {
     try {
         initializeFramework7();
         updateStatus(mhaStrings.mhaLoading);

--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -7,6 +7,7 @@ import Framework7 from "framework7";
 import Accordion from "framework7/components/accordion";
 import Dialog from "framework7/components/dialog";
 import Preloader from "framework7/components/preloader";
+import Progressbar from "framework7/components/progressbar";
 import $ from "jquery";
 
 import { HeaderModel } from "../HeaderModel";
@@ -30,7 +31,7 @@ function postError(error: unknown, message: string): void {
 
 function initializeFramework7(): void {
     // Install Framework7 components
-    Framework7.use([Preloader, Dialog, Accordion]);
+    Framework7.use([Preloader, Dialog, Accordion, Progressbar]);
 
     myApp = new Framework7({
         // App name

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,6 +163,26 @@ export default async (env, options) => {
                 __BUILDTIME__: JSON.stringify(buildTime),
             }),
             new ForkTsCheckerWebpackPlugin(),
+            // Custom plugin to log compilation start/end times with timestamps
+            {
+                apply(compiler) {
+                    compiler.hooks.watchRun.tap("TimestampPlugin", () => {
+                        const timestamp = new Date().toISOString().replace("T", " ").substr(0, 19);
+                        console.log(`\n🔄 [${timestamp}] WEBPACK RECOMPILATION STARTED`);
+                    });
+
+                    compiler.hooks.done.tap("TimestampPlugin", (stats) => {
+                        const timestamp = new Date().toISOString().replace("T", " ").substr(0, 19);
+                        const compilationTime = stats.endTime - stats.startTime;
+                        console.log(`✅ [${timestamp}] WEBPACK RECOMPILATION COMPLETED (${compilationTime}ms)\n`);
+                    });
+
+                    compiler.hooks.invalid.tap("TimestampPlugin", (fileName) => {
+                        const timestamp = new Date().toISOString().replace("T", " ").substr(0, 19);
+                        console.log(`📝 [${timestamp}] FILE CHANGED: ${fileName}`);
+                    });
+                }
+            },
             ...generateHtmlWebpackPlugins(),
             // Bundle analyzer (when env.analyze is set)
             ...(env?.analyze ? [new BundleAnalyzerPlugin({
@@ -287,7 +307,12 @@ export default async (env, options) => {
                 "X-XSS-Protection": "1; mode=block", // eslint-disable-line @typescript-eslint/naming-convention
                 "Referrer-Policy": "strict-origin-when-cross-origin", // eslint-disable-line @typescript-eslint/naming-convention
             },
-            static: __dirname,
+            static: {
+                directory: __dirname,
+                watch: false, // Disable watching of static files
+                publicPath: "/",
+                serveIndex: false
+            },
             watchFiles: {
                 paths: [
                     "src/**/*.{ts,js,css}",
@@ -300,6 +325,7 @@ export default async (env, options) => {
                         "**/coverage/**",
                         "**/*.map",
                         "**/*.log",
+                        "**/*.md", // Explicitly ignore markdown files
                         ".gitignore",
                         ".gitattributes"
                     ],
@@ -321,6 +347,8 @@ export default async (env, options) => {
                     warnings: false,
                 },
                 progress: true,
+                logging: "verbose", // Changed from "info" to "verbose" for more details
+                reconnect: 5,
             },
         },
         stats: {
@@ -334,6 +362,12 @@ export default async (env, options) => {
             warnings: true,
             errors: true,
             errorDetails: true,
+            logging: "info",
+            loggingDebug: ["webpack.Progress"],
+        },
+        infrastructureLogging: {
+            level: "info",
+            debug: false,
         },
     };
 


### PR DESCRIPTION
This pull request modernizes the mobile pane iOS frame by upgrading Framework7 to v8, refactoring the HTML structure to use the latest Framework7 tab system, and introducing improved CSS and accessibility support. It also removes legacy Framework7 import logic and adds comprehensive accessibility unit tests for DOM utilities.

**Framework7 Upgrade & UI Refactor:**

* Upgraded `framework7` from v1.7.1 to v8.3.4 in `package.json`, enabling use of modern Framework7 features and components.
* Refactored the HTML structure in `src/Pages/newMobilePaneIosFrame.html` to use Framework7 v8's tab system, with a single root view and proper tab containers for summary, received, antispam, and other sections. Also added a responsive viewport meta tag. [[1]](diffhunk://#diff-7a1c850796b00e737c5954483e8da51ff08f5622f307ef8d31e43134e17f2ef0R6-R17) [[2]](diffhunk://#diff-7a1c850796b00e737c5954483e8da51ff08f5622f307ef8d31e43134e17f2ef0R34-R68)

**Styling Updates:**

* Overhauled `src/Content/newMobilePaneIosFrame.css` to use CSS variables for theme consistency, updated tab and block styling for Framework7 v8, and added specific styles for new views (antispam, received). [[1]](diffhunk://#diff-d2fab1bce9fc5c6201ac47b85dc2b41b4741db8aea35a77cb8910301873348c3R2-R58) [[2]](diffhunk://#diff-d2fab1bce9fc5c6201ac47b85dc2b41b4741db8aea35a77cb8910301873348c3L23-R101) [[3]](diffhunk://#diff-d2fab1bce9fc5c6201ac47b85dc2b41b4741db8aea35a77cb8910301873348c3L63-R159)

**Accessibility Improvements:**

* Added extensive unit tests in `src/Scripts/ui/domUtils.test.ts` for new accessibility methods, including focus management and ARIA attributes, ensuring better usability for screen readers and keyboard navigation.

**Codebase Cleanup:**

* Removed legacy Framework7 import/export logic from `src/Scripts/framework7.ts`, as the new version supports standard ES module imports.