### PR TITLE
keyboard support for received tab

### DIFF
--- a/src/Scripts/ui/newMobilePaneIosFrame.ts
+++ b/src/Scripts/ui/newMobilePaneIosFrame.ts
@@ -53,6 +53,49 @@ function updateStatus(message: string): void {
     }
 }
 
+function handleTimelineKeyboardActivation(event: KeyboardEvent): void {
+    if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        const target = event.target as HTMLElement;
+
+        // Check if there's already an open popover
+        const openPopovers = document.querySelectorAll(".popover.modal-in");
+
+        if (openPopovers.length > 0 && myApp) {
+            // If a popover is open, close it
+            openPopovers.forEach(popover => {
+                const popoverInstance = myApp!.popover.get(popover as HTMLElement);
+                if (popoverInstance) {
+                    popoverInstance.close();
+                }
+            });
+        } else {
+            // If no popover is open, simulate a click to trigger Framework7's popover handling
+            target.click();
+        }
+    }
+}
+
+function handlePopoverDismissalKeys(event: KeyboardEvent): void {
+    // Check if any popovers are open
+    const openPopovers = document.querySelectorAll(".popover.modal-in");
+
+    if (event.key === "Escape") {
+        // Escape always closes popovers if they're open
+        if (openPopovers.length > 0 && myApp) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            openPopovers.forEach(popover => {
+                const popoverInstance = myApp!.popover.get(popover as HTMLElement);
+                if (popoverInstance) {
+                    popoverInstance.close();
+                }
+            });
+        }
+    }
+}
+
 function addCalloutEntry(name: string, value: string | number | null, parent: HTMLElement): void {
     if (value) {
         const p = document.createElement("p");
@@ -181,6 +224,10 @@ function buildViews(headers: string): void {
                 const timelineInner = document.createElement("div");
                 timelineInner.className = "timeline-item-inner link popover-open";
                 timelineInner.setAttribute("data-popover", ".popover-" + i);
+                timelineInner.setAttribute("tabindex", "0");
+                timelineInner.setAttribute("role", "button");
+                timelineInner.setAttribute("aria-label", `View details for message received at ${currentTime.format("h:mm:ss")} from ${row.from}`);
+                timelineInner.addEventListener("keydown", handleTimelineKeyboardActivation);
                 currentTimeEntry.appendChild(timelineInner);
 
                 const timelineTime = document.createElement("div");
@@ -229,6 +276,10 @@ function buildViews(headers: string): void {
                 const timelineInner = document.createElement("div");
                 timelineInner.className = "timeline-item-inner link popover-open";
                 timelineInner.setAttribute("data-popover", ".popover-" + i);
+                timelineInner.setAttribute("tabindex", "0");
+                timelineInner.setAttribute("role", "button");
+                timelineInner.setAttribute("aria-label", `View details for message received at ${entryTime.format("h:mm:ss")} to ${row.by}`);
+                timelineInner.addEventListener("keydown", handleTimelineKeyboardActivation);
                 currentTimeEntry.appendChild(timelineInner);
 
                 const timelineTime = document.createElement("div");
@@ -507,6 +558,7 @@ document.addEventListener("DOMContentLoaded", function() {
         initializeFramework7();
         updateStatus(mhaStrings.mhaLoading);
         window.addEventListener("message", eventListener, false);
+        document.addEventListener("keydown", handlePopoverDismissalKeys);
         Poster.postMessageToParent("frameActive");
     }
     catch (e) {


### PR DESCRIPTION
This pull request enhances the accessibility and keyboard navigation of timeline popovers in the `newMobilePaneIosFrame.ts` UI. The main improvements include adding keyboard event handlers to allow opening and closing popovers using the keyboard, as well as updating timeline items to be accessible buttons with appropriate ARIA attributes.

**Accessibility and Keyboard Navigation Improvements:**

* Added `handleTimelineKeyboardActivation` and `handlePopoverDismissalKeys` functions to support opening popovers with Enter/Space and closing them with Escape, improving keyboard accessibility for timeline items.
* Registered a global event listener for keyboard events to handle popover dismissal with the Escape key.

**Timeline Item Accessibility Enhancements:**

* Updated timeline items (`timelineInner` elements) to be focusable (`tabindex="0"`), have button roles, and include descriptive `aria-labels` for screen readers. Also attached the keyboard activation handler to enable keyboard-triggered popover opening. [[1]](diffhunk://#diff-4664965c566e80c001501551a920453bfa863087b3752e5f3a7bc8977625168aR227-R230) [[2]](diffhunk://#diff-4664965c566e80c001501551a920453bfa863087b3752e5f3a7bc8977625168aR279-R282)