### PR TITLE
Standalone MHA Fixes

### DIFF
--- a/src/Pages/mha.html
+++ b/src/Pages/mha.html
@@ -75,6 +75,16 @@
             </div>
         </div>
     </template>
+
+    <template id="diagnostic-accordion-item-template">
+        <div class="diagnostic-group">
+            <div class="violation-card-header">
+                <span class="severity-badge"></span>
+                <span class="violation-message"></span>
+            </div>
+            <div class="diagnostic-content diagnostic-violations"></div>
+        </div>
+    </template>
 </body>
 
 </html>

--- a/src/Scripts/ui/Table.ts
+++ b/src/Scripts/ui/Table.ts
@@ -123,6 +123,7 @@ export class Table {
 
             rows.forEach((summaryRow: Row) => {
                 const id = summaryRow.header + tag;
+                if (document.getElementById(id)) return; // Skip if already exists
                 const row = document.createElement("tr");
                 if (row !== null) {
                     row.id = id;
@@ -400,9 +401,10 @@ export class Table {
     }
 
     private addColumns(tableName: string, columns: Column[]): void {
-        const tableHeader = document.createElement("thead");
         const table = document.getElementById(tableName);
         if (table) {
+            if (table.querySelector("thead")) return; // Skip if already has headers
+            const tableHeader = document.createElement("thead");
             table.appendChild(tableHeader);
 
             const headerRow = document.createElement("tr");
@@ -496,6 +498,8 @@ export class Table {
     private setupReceivedHeadersUI(): void {
         const withColumn = document.querySelector("#receivedHeaders #with");
         if (withColumn !== null) {
+            if (document.getElementById("leftArrow")) return; // Skip if already exists
+
             const leftSpan = document.createElement("span");
             leftSpan.setAttribute("id", "leftArrow");
             leftSpan.classList.add("collapsibleArrow");

--- a/src/Scripts/ui/mha.ts
+++ b/src/Scripts/ui/mha.ts
@@ -93,6 +93,10 @@ async function analyze() {
     }
 
     viewModel = await HeaderModel.create(headerText);
+
+    // Clear UI first to ensure clean slate (same as Clear button)
+    table.rebuildSections(null);
+
     table.resetArrows();
 
     enableSpinner();

--- a/src/Scripts/ui/mha.ts
+++ b/src/Scripts/ui/mha.ts
@@ -94,7 +94,7 @@ async function analyze() {
 
     viewModel = await HeaderModel.create(headerText);
 
-    // Clear UI first to ensure clean slate (same as Clear button)
+    // Clear UI before rebuilding to ensure clean state
     table.rebuildSections(null);
 
     table.resetArrows();


### PR DESCRIPTION
This pull request fixes some regressions in the standalone MHA page.

**UI Rendering Improvements:**

* Prevents duplicate rows in tables by checking for existing row IDs before adding new ones in `Table.ts`.
* Skips adding table headers if they already exist, avoiding duplicate `<thead>` elements in `Table.ts`.
* Ensures that the left arrow UI element is only added once by checking for its existence in `Table.ts`.
* Clears the UI state before rebuilding sections in the `analyze` function to avoid residual artifacts.
* Adds missing `diagnostic-accordion-item-template` to `mha.html` for rendering diagnostic group items