### PR TITLE
Various A11y Bugfixes

### DIFF
--- a/src/Content/classicDesktopFrame.css
+++ b/src/Content/classicDesktopFrame.css
@@ -288,7 +288,7 @@ button[aria-expanded="false"] .collapsibleSwitch::after {
     box-sizing: border-box;
 }
 
-#mhaFooter {
+#feedbackLink {
     float: right;
 }
 

--- a/src/Content/fluentCommon.css
+++ b/src/Content/fluentCommon.css
@@ -269,7 +269,7 @@ fluent-radio:focus-visible {
 /* Common Status Overlay Styles for Copy Feedback */
 /* Used by both uitoggle and standalone MHA pages */
 .status-overlay {
-    display: none;
+    display: block;
     color: var(--success-green); /* Dark green text for contrast */
     font-size: 14px;
     font-weight: 500;
@@ -288,7 +288,6 @@ fluent-radio:focus-visible {
 }
 
 .status-overlay.show {
-    display: block;
     opacity: 1;
     transform: translateX(0);
 }

--- a/src/Pages/mha.html
+++ b/src/Pages/mha.html
@@ -13,7 +13,7 @@
         <h1 id="title">Message Header Analyzer</h1>
     </header>
     <main id="SectionContent">
-        <section aria-labelledby="inputSection">
+        <section role="region" aria-label="Input Headers">
             <h2 id="inputSection" class="sr-only">Input Headers</h2>
             <textarea id="inputHeaders" autofocus="autofocus" placeholder="Paste headers here." required="required"
                 rows="15"></textarea>
@@ -35,14 +35,14 @@
                 <div class="status-overlay status-overlay-inline" id="copyStatusMessage" role="status" aria-live="polite">
                 </div>
             </fluent-button>
-            <footer id="mhaFooter">
+            <div id="feedbackLink">
                 <a href="https://github.com/microsoft/MHA" target="_blank" rel="noopener">Submit feedback on github</a>
-            </footer>
+            </div>
         </section>
 
         <hr id="lineBreak" />
 
-        <section id="response" class="hiddenElement" aria-labelledby="resultsSection">
+        <section id="response" class="hiddenElement" role="region" aria-label="Analysis Results">
             <h2 id="resultsSection" class="sr-only">Analysis Results</h2>
             <div class="responsePane">
                 <div id="status"></div>

--- a/src/Pages/uitoggle.html
+++ b/src/Pages/uitoggle.html
@@ -23,7 +23,6 @@
 
         <!-- Status message overlay positioned as true overlay -->
         <div id="statusMessage" class="status-overlay status-overlay-fixed" role="status" aria-live="polite">
-            Copied to clipboard!
         </div>
 
         <section class="frame-row">

--- a/src/Scripts/ParentFrame.ts
+++ b/src/Scripts/ParentFrame.ts
@@ -2,6 +2,7 @@
 import { DeferredError } from "./DeferredError";
 import { diagnostics } from "./Diag";
 import { Errors } from "./Errors";
+import { mhaStrings } from "./mhaStrings";
 import { Poster } from "./Poster";
 import { Strings } from "./Strings";
 import { TabNavigation } from "./TabNavigation";
@@ -340,11 +341,13 @@ export class ParentFrame {
             // Show status message for accessibility
             const statusMessage = document.getElementById("statusMessage");
             if (statusMessage) {
+                statusMessage.textContent = mhaStrings.mhaCopied;
                 statusMessage.classList.add("show");
 
                 // Hide after 2 seconds
                 setTimeout(() => {
                     statusMessage.classList.remove("show");
+                    statusMessage.textContent = "";
                 }, 2000);
             }
 

--- a/src/Scripts/ui/mha.ts
+++ b/src/Scripts/ui/mha.ts
@@ -58,6 +58,8 @@ function dismissAllStatusMessages() {
     // Find all status overlay elements and hide them
     document.querySelectorAll(".status-overlay-inline.show").forEach(element => {
         element.classList.remove("show");
+        // Clear text content so next announcement is detected as a change
+        element.textContent = "";
     });
 }
 
@@ -74,6 +76,7 @@ function showStatusMessage(elementId: string, message: string, duration = 2000) 
         // Hide after specified duration and track the timeout
         const timeoutId = setTimeout(() => {
             statusElement.classList.remove("show");
+            statusElement.textContent = "";
             statusMessageTimeouts.delete(elementId);
         }, duration);
 
@@ -114,9 +117,13 @@ function clear() {
     DomUtils.setValue("#inputHeaders", "");
 
     table.rebuildSections(null);
-    document.getElementById("inputHeaders")?.focus();
 
     showStatusMessage("clearStatusMessage", mhaStrings.mhaCleared);
+
+    // Delay focus to allow screen reader to fully announce status message
+    setTimeout(() => {
+        document.getElementById("inputHeaders")?.focus();
+    }, 1000);
 }
 
 function copy() {


### PR DESCRIPTION
This pull request introduces accessibility and UI improvements across several files, focusing on status message overlays, feedback link placement, and semantic HTML enhancements. The main changes ensure status messages are properly announced for assistive technologies, feedback links are more appropriately styled, and sections are more accessible via ARIA attributes.

**Accessibility and UI improvements:**

* Status message overlays now clear their text content when hidden, ensuring that screen readers detect new announcements and improving accessibility for users relying on assistive technology. (`src/Scripts/ui/mha.ts`, `src/Scripts/ParentFrame.ts`) [[1]](diffhunk://#diff-176e73d159e57ea903ca9d8d20f05ad0aac867629ce4d13b5802f2b1ad995724R61-R62) [[2]](diffhunk://#diff-176e73d159e57ea903ca9d8d20f05ad0aac867629ce4d13b5802f2b1ad995724R79) [[3]](diffhunk://#diff-dd7674246b863b108485d1812910103487a75ee55aafd17d9d76673f76002decR344-R350)
* The focus on the `inputHeaders` textarea after clearing is now delayed to allow screen readers to finish announcing status messages, preventing interruptions. (`src/Scripts/ui/mha.ts`)

**Styling and layout updates:**

* The feedback link is now styled with `#feedbackLink` instead of `#mhaFooter`, and its markup is updated to use a `div` rather than a `footer`, improving consistency and semantic correctness. (`src/Content/classicDesktopFrame.css`, `src/Pages/mha.html`) [[1]](diffhunk://#diff-7bb442a9ced039841e447e3d493847fd794200b540a40578d4cfe8bc2909a7e8L291-R291) [[2]](diffhunk://#diff-57b47ddb28679ef9430c24a402d3b97f7dc9cd160406ddec7871acf380f14062L38-R45)

**Semantic HTML and ARIA enhancements:**

* Main content sections now use `role="region"` and `aria-label` attributes for better accessibility, making navigation easier for screen reader users. (`src/Pages/mha.html`) [[1]](diffhunk://#diff-57b47ddb28679ef9430c24a402d3b97f7dc9cd160406ddec7871acf380f14062L16-R16) [[2]](diffhunk://#diff-57b47ddb28679ef9430c24a402d3b97f7dc9cd160406ddec7871acf380f14062L38-R45)
* The analysis results section also adopts these improvements for consistency. (`src/Pages/mha.html`)

**Status overlay display logic:**

* The `.status-overlay` CSS class now uses `display: block` by default, and the `.show` modifier no longer sets the display property, streamlining the overlay's visibility logic. (`src/Content/fluentCommon.css`) [[1]](diffhunk://#diff-94591eb8f88aeb3a84e5031ff767ed17ff7c953acc802d65372f1dc70755a56fL272-R272) [[2]](diffhunk://#diff-94591eb8f88aeb3a84e5031ff767ed17ff7c953acc802d65372f1dc70755a56fL291)

**Code cleanup:**

* Removed hardcoded status message text from the HTML and now set it programmatically for better localization and maintainability. (`src/Pages/uitoggle.html`, `src/Scripts/ParentFrame.ts`) [[1]](diffhunk://#diff-c11ade619b53e8fd13ce346352dd2d54a64d3f2e9135fbc344d3c23825ae5c72L26) [[2]](diffhunk://#diff-dd7674246b863b108485d1812910103487a75ee55aafd17d9d76673f76002decR344-R350)

Addresses following issues:
Bug 1691349 Screen Readers-Message Header Analyzer: Landmarks are not defined on the page.
Bug 1986059 Color Contrast- Summary: Contrast ratio of multiple text is less than 4.5:1 in "Summary" screen.
Bug 1986097 Focus order- Message header analyzer: Keyboard focus is going to whole dialog instead of close button.
Bug 1987489 Status Message- Classic: No status message appearing on screen for "Copy" mail
Bug 1987498 Status Message- Message Header Analyzer: No status message appearing on screen for actions like analyze header, clear, and other controls in Message Header Analyzer screen