### PR TITLE
fix webpack params to match v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "clean": "node tasks/clean.js",
     "watch": "webpack --watch --mode=development",
-    "build": "webpack --mode=production --node-env=production",
+    "build": "webpack --mode=production --env=prod",
     "build:dev": "webpack --mode=development",
     "build:analyze": "webpack --mode=production --env analyze",
     "serve": "webpack serve --mode=development",


### PR DESCRIPTION
This pull request makes a minor update to the `build` script in `package.json` to improve consistency with other environment variable usage.

- Updated the `build` script to use `--env=prod` instead of `--node-env=production` for specifying the production environment.